### PR TITLE
Add omg binary to path before use

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Simply run:
 
     $ pip3 install o-must-gather --user
 
+The omg binary is installed at ~/.local/bin, if it is not on your $PATH, create a symlink:
+
+    $ ln -s ~/.local/bin ~/bin
+
 
 # Usage
 


### PR DESCRIPTION
On a fresh install, it took me some time to locate the omg binary at `~/.local/bin/omg` which isn't always on $PATH, so I added a recommendation to the README.