### PR TITLE
Fix missing role issue in "get nodes"

### DIFF
--- a/omg/cmd/get/node_out.py
+++ b/omg/cmd/get/node_out.py
@@ -35,7 +35,7 @@ def node_out(t, ns, res, output, show_type):
         # roles
         roles = []
         for label in n['metadata']['labels']:
-            if label.startswith('node-role.kubernetes.io'):
+            if label.startswith('node-role.kubernetes.io/'):
                 roles.append(label.split('/')[1])
         row.append(','.join(roles))
         # age


### PR DESCRIPTION
This PR addresses a small issue that will prevent a program fault if nodes contain a label with `node-role.kubernetes.io` that has no `/<role>` qualifier. (a situation I find myself in with some OpenShift deployments)

This fix should not impact existing behaviour of `omg`, but simply ensures that before running the `split` on the `/` separator, that the actual separator exists in the string.


