### PR TITLE
Implement a number of new resources and tweaked some displays

### DIFF
--- a/omg/cmd/get/bc_out.py
+++ b/omg/cmd/get/bc_out.py
@@ -1,0 +1,41 @@
+from tabulate import tabulate
+
+from omg.common.helper import age
+
+
+def bc_out(t, ns, res, output, show_type):
+    output_res=[[]]
+    # header
+    if ns == '_all':
+        output_res[0].append('NAMESPACE')
+    output_res[0].extend(['NAME','TYPE','FROM','LATEST'])
+    # resources
+    for r in res:
+        bc = r['res']
+        row = []
+        # namespace (for --all-namespaces)
+        if ns == '_all':
+            row.append(bc['metadata']['namespace'])
+        # name
+        if show_type:
+            row.append(t + '/' + bc['metadata']['name'])
+        else:
+            row.append(bc['metadata']['name'])
+        # type
+        try:
+            row.append(bc['spec']['strategy']['type'])
+        except:
+            row.append('??')
+        # from
+        try:
+            row.append(bc['spec']['source']['type'])
+        except:
+            row.append('??')
+        # latest
+        try:
+            row.append(bc['status']['lastVersion'])
+        except:
+            row.append('??')
+        output_res.append(row)
+
+    print(tabulate(output_res,tablefmt="plain"))

--- a/omg/cmd/get/build_out.py
+++ b/omg/cmd/get/build_out.py
@@ -1,0 +1,53 @@
+from tabulate import tabulate
+
+from omg.common.helper import age
+
+
+def build_out(t, ns, res, output, show_type):
+    output_res=[[]]
+    # header
+    if ns == '_all':
+        output_res[0].append('NAMESPACE')
+    output_res[0].extend(['NAME','TYPE','FROM','STATUS', 'STARTED','DURATION'])
+    # resources
+    for r in res:
+        build = r['res']
+        row = []
+        # namespace (for --all-namespaces)
+        if ns == '_all':
+            row.append(build['metadata']['namespace'])
+        # name
+        if show_type:
+            row.append(t + '/' + build['metadata']['name'])
+        else:
+            row.append(build['metadata']['name'])
+        # type
+        try:
+            row.append(build['spec']['strategy']['type'])
+        except:
+            row.append('??')
+        # from
+        try:
+            row.append(build['spec']['source']['type'])
+        except:
+            row.append('??')
+        # status
+        try:
+            row.append(build['status']['phase'])
+        except:
+            row.append('??')
+        # started
+        try:
+            ct = str(build['status']['startTimestamp'])
+            ts = r['gen_ts']
+            row.append(age(ct,ts))
+        except:
+            row.append('Unknown')
+        # duration
+        try:
+            row.append(str(int((build['status']['duration']) / 1000000000)) + 's')
+        except:
+            row.append('Unknown')
+        output_res.append(row)
+
+    print(tabulate(output_res,tablefmt="plain"))

--- a/omg/cmd/get/cj_out.py
+++ b/omg/cmd/get/cj_out.py
@@ -1,0 +1,55 @@
+from tabulate import tabulate
+
+from omg.common.helper import age
+
+
+def cj_out(t, ns, res, output, show_type):
+    output_res=[[]]
+    # header
+    if ns == '_all':
+        output_res[0].append('NAMESPACE')
+    output_res[0].extend(['NAME','SCHEDULE','SUSPEND','ACTIVE', 'LAST SCHEDULE','AGE'])
+    # resources
+    for r in res:
+        cj = r['res']
+        row = []
+        # namespace (for --all-namespaces)
+        if ns == '_all':
+            row.append(cj['metadata']['namespace'])
+        # name
+        if show_type:
+            row.append(t + '/' + cj['metadata']['name'])
+        else:
+            row.append(cj['metadata']['name'])
+        # schedule
+        try:
+            row.append(cj['spec']['schedule'])
+        except:
+            row.append('??')
+        # suspend
+        try:
+            row.append(cj['spec']['suspend'])
+        except:
+            row.append('??')
+        # active
+        try:
+            row.append(len(cj['status']['active']))
+        except:
+            row.append('0')
+        # last schedule
+        try:
+            ct = str(cj['status']['lastScheduleTime'])
+            ts = r['gen_ts']
+            row.append(age(ct,ts))
+        except:
+            row.append('Unknown')
+        # age
+        try:
+            ct = str(cj['metadata']['creationTimestamp'])
+            ts = r['gen_ts']
+            row.append(age(ct,ts))
+        except:
+            row.append('Unknown')
+        output_res.append(row)
+
+    print(tabulate(output_res,tablefmt="plain"))

--- a/omg/cmd/get/crd_out.py
+++ b/omg/cmd/get/crd_out.py
@@ -1,0 +1,33 @@
+from tabulate import tabulate
+
+from omg.common.helper import age
+
+
+# Simple out put with just name and age
+def crd_out(t, ns, res, output, show_type):
+    output_res=[]
+    # header
+    # we will append the header array at last after sorting
+    header = ['NAME','CREATED AT']
+    # resources
+    for r in res:
+        p = r['res']
+        row = []
+        # name
+        if show_type:
+            row.append(t + '/' + p['metadata']['name'])
+        else:
+            row.append(p['metadata']['name'])
+        # creation timestamp
+        try:
+            row.append(p['metadata']['creationTimestamp'])
+        except:
+            row.append('Unknown')
+
+        output_res.append(row)
+
+    # sort by 1st column
+    sorted_output = sorted(output_res)
+    sorted_output.insert(0,header)
+
+    print(tabulate(sorted_output,tablefmt="plain"))

--- a/omg/cmd/get/dc_out.py
+++ b/omg/cmd/get/dc_out.py
@@ -1,0 +1,51 @@
+from tabulate import tabulate
+
+from omg.common.helper import age
+
+
+def dc_out(t, ns, res, output, show_type):
+    output_res=[[]]
+    # header
+    if ns == '_all':
+        output_res[0].append('NAMESPACE')
+    output_res[0].extend(['NAME','REVISION','DESIRED','CURRENT','TRIGGERED BY'])
+    # resources
+    for r in res:
+        dc = r['res']
+        row = []
+        # namespace (for --all-namespaces)
+        if ns == '_all':
+            row.append(dc['metadata']['namespace'])
+        # name
+        if show_type:
+            row.append(t + '/' + dc['metadata']['name'])
+        else:
+            row.append(dc['metadata']['name'])
+        # revision
+        try:
+            row.append(dc['status']['latestVersion'])
+        except:
+            row.append('??')
+        # desired
+        try:
+            row.append(dc['spec']['replicas'])
+        except:
+            row.append('??')
+        # current
+        try:
+            row.append(dc['status']['readyReplicas'])
+        except:
+            row.append('??')
+        # triggered by
+        try:
+            triggered_type = dc['spec']['triggers'][0].get('type')
+            if triggered_type == 'ConfigChange':
+                row.append('config')
+            else:
+                row.append(triggered_type)
+        except:
+            row.append('??')
+
+        output_res.append(row)
+
+    print(tabulate(output_res,tablefmt="plain"))

--- a/omg/cmd/get/ds_out.py
+++ b/omg/cmd/get/ds_out.py
@@ -1,0 +1,77 @@
+from tabulate import tabulate
+import sys, yaml, json
+
+from omg.common.helper import age
+
+
+def ds_out(t, ns, res, output, show_type):
+    output_res=[[]]
+    # header
+    if ns == '_all':
+        output_res[0].append('NAMESPACE')
+    output_res[0].extend(['NAME','DESIRED','CURRENT','READY','UP-TO-DATE','AVAILABLE','NODE SELECTOR','AGE'])
+    if output == 'wide':
+        output_res[0].extend(['CONTAINERS','IMAGES'])
+    # resources
+    for r in res:
+        ds = r['res']
+        row = []
+        # namespace (for --all-namespaces)
+        if ns == '_all':
+            row.append(ds['metadata']['namespace'])
+        # name
+        if show_type:
+            row.append(t + '/' + ds['metadata']['name'])
+        else:
+            row.append(ds['metadata']['name'])
+        # desired
+        try:
+            row.append(ds['status']['desiredNumberScheduled'])
+        except:
+            row.append('??')
+        # current
+        try:
+            row.append(ds['status']['currentNumberScheduled'])
+        except:
+            row.append('??')
+        # ready
+        try:
+            row.append(ds['status']['numberReady'])
+        except:
+            row.append('??')
+        # up-to-date
+        try:
+            row.append(ds['status']['updatedNumberScheduled'])
+        except:
+            row.append('??')
+        # available
+        try:
+            row.append(ds['status']['numberAvailable'])
+        except:
+            row.append('??')
+        # node selector
+        try:
+            nodeselector = ds['spec']['template']['spec']['nodeSelector']
+            for k, v in nodeselector.items():
+                row.append(k + '=' + v)
+        except:
+            row.append('??')
+        # age
+        try:
+            ct = str(ds['metadata']['creationTimestamp'])
+            ts = r['gen_ts']
+            row.append(age(ct,ts))
+        except:
+            row.append('Unknown')
+        # -o wide
+        if output == 'wide':
+            # container:
+            conts = [ c['name'] for c in ds['spec']['template']['spec']['containers'] ]
+            row.append(','.join(conts))
+            # images:
+            images = [ c['image'] for c in ds['spec']['template']['spec']['containers'] ]
+            row.append(','.join(images))
+
+        output_res.append(row)
+
+    print(tabulate(output_res,tablefmt="plain"))

--- a/omg/cmd/get/eps_out.py
+++ b/omg/cmd/get/eps_out.py
@@ -1,0 +1,79 @@
+from tabulate import tabulate
+
+from omg.common.helper import age
+
+
+# endpoint out
+def eps_out(t, ns, res, output, show_type):
+    output_res=[[]]
+    # header
+    if ns == '_all':
+        output_res[0].append('NAMESPACE')
+    output_res[0].extend(['NAME','ADDRESSTYPE','PORTS','ENDPOINTS','AGE'])
+    # resources
+    for r in res:
+        eps = r['res']
+        row = []
+        # namespace (for --all-namespaces)
+        if ns == '_all':
+            row.append(eps['metadata']['namespace'])
+        # name
+        if show_type:
+            row.append(t + '/' + eps['metadata']['name'])
+        else:
+            row.append(eps['metadata']['name'])
+        # addresstype
+            row.append(eps['addressType'])
+        # ports
+        ports = []
+        if 'ports' in eps and eps['ports'] is not None:
+            for s in eps['ports']:
+                ports.append(
+                    str(str(s['port']))
+                )
+        if len(ports) == 0:
+            row.append('<none>')
+        elif len(ports) < 4:
+            row.append(
+                ','.join(ports)
+            )
+        else:
+            row.append(
+                ','.join(ports[:3]) +
+                ' + ' +
+                str(len(ports)-3) +
+                ' more...'
+            )
+        
+        # endpoints
+        endpoints = []
+        if 'endpoints' in eps and eps['endpoints'] is not None:
+            for s in eps['endpoints']:
+                endpoints.append(
+                    str(s['addresses'][0])
+                )
+        if len(endpoints) == 0:
+            row.append('<none>')
+        elif len(endpoints) < 4:
+            row.append(
+                ','.join(endpoints)
+            )
+        else:
+            row.append(
+                ','.join(endpoints[:3]) +
+                ' + ' +
+                str(len(endpoints)-3) +
+                ' more...'
+            )
+        
+        # age
+        try:
+            ct = str(eps['metadata']['creationTimestamp'])
+            ts = r['gen_ts']
+            row.append(age(ct,ts))
+        except:
+            row.append('Unknown')
+
+        output_res.append(row)
+
+    print(tabulate(output_res,tablefmt="plain"))

--- a/omg/cmd/get/hpa_out.py
+++ b/omg/cmd/get/hpa_out.py
@@ -1,0 +1,65 @@
+from tabulate import tabulate
+
+from omg.common.helper import age
+
+
+def hpa_out(t, ns, res, output, show_type):
+    output_res=[[]]
+    # header
+    if ns == '_all':
+        output_res[0].append('NAMESPACE')
+    output_res[0].extend(['NAME','REFERENCE','TARGETS','MINPODS', 'MAXPODS','REPLICAS','AGE'])
+    # resources
+    for r in res:
+        hpa = r['res']
+        row = []
+        # namespace (for --all-namespaces)
+        if ns == '_all':
+            row.append(hpa['metadata']['namespace'])
+        # name
+        if show_type:
+            row.append(t + '/' + hpa['metadata']['name'])
+        else:
+            row.append(hpa['metadata']['name'])
+        # reference
+        try:
+            row.append(hpa['spec']['scaleTargetRef']['kind'] + '/' + hpa['spec']['scaleTargetRef']['name'])
+        except:
+            row.append('??')
+        # targets
+        try:
+            # test numerator
+            try:
+                target_num = str(hpa['status']['currentCPUUtilizationPercentage']) + '%'
+            except:
+                target_num = '<unknown>'
+            # append denominator
+            target_den = str(hpa['spec']['targetCPUUtilizationPercentage']) + '%'
+            row.append(target_num + '/' + target_den)
+        except:
+            row.append('??')
+        # minpods
+        try:
+            row.append(hpa['spec']['minReplicas'])
+        except:
+            row.append('??')
+        # maxpods
+        try:
+            row.append(hpa['spec']['maxReplicas'])
+        except:
+            row.append('??')
+        # replicas
+        try:
+            row.append(hpa['status']['currentReplicas'])
+        except:
+            row.append('??')
+        # age
+        try:
+            ct = str(hpa['metadata']['creationTimestamp'])
+            ts = r['gen_ts']
+            row.append(age(ct,ts))
+        except:
+            row.append('Unknown')
+        output_res.append(row)
+
+    print(tabulate(output_res,tablefmt="plain"))

--- a/omg/cmd/get/is_out.py
+++ b/omg/cmd/get/is_out.py
@@ -1,0 +1,47 @@
+from tabulate import tabulate
+
+from omg.common.helper import age
+
+def is_out(t, ns, res, output, show_type):
+    output_res=[[]]
+    # header
+    if ns == '_all':
+        output_res[0].append('NAMESPACE')
+    output_res[0].extend(['NAME','IMAGE REPOSITORY','TAGS','UPDATED'])
+    # resources
+    for r in res:
+        is_ = r['res']
+        row = []
+        # namespace (for --all-namespaces)
+        if ns == '_all':
+            row.append(is_['metadata']['namespace'])
+        # name
+        if show_type:
+            row.append(t + '/' + is_['metadata']['name'])
+        else:
+            row.append(is_['metadata']['name'])
+        # image repository
+        try:
+            row.append(is_['status']['publicDockerImageRepository'])
+        except:
+            row.append('??')
+        # tags
+        try:
+            tags = []
+            for tag in is_['status']['tags']:
+                tags.append(tag['tag'])
+            row.append(','.join(tags))
+        except:
+            row.append('??')
+        # updated
+        ## TODO: should update this to parse list of tags and determine latest updated image, rather than use metadata.creationTimestamp
+        try:
+            ct = str(is_['metadata']['creationTimestamp'])
+            ts = r['gen_ts']
+            row.append(age(ct,ts))
+        except:
+            row.append('Unknown')
+
+        output_res.append(row)
+
+    print(tabulate(output_res,tablefmt="plain"))

--- a/omg/cmd/get/is_out.py
+++ b/omg/cmd/get/is_out.py
@@ -24,7 +24,7 @@ def is_out(t, ns, res, output, show_type):
         try:
             row.append(is_['status']['publicDockerImageRepository'])
         except:
-            row.append('??')
+            row.append('')
         # tags
         try:
             tags = []
@@ -32,15 +32,19 @@ def is_out(t, ns, res, output, show_type):
                 tags.append(tag['tag'])
             row.append(','.join(tags))
         except:
-            row.append('??')
+            row.append('')
         # updated
         ## TODO: should update this to parse list of tags and determine latest updated image, rather than use metadata.creationTimestamp
         try:
-            ct = str(is_['metadata']['creationTimestamp'])
-            ts = r['gen_ts']
-            row.append(age(ct,ts))
+            ## TODO: replace this check when reimplementing latest updated image
+            if len(is_['status']['tags']) > 0:
+                ct = str(is_['metadata']['creationTimestamp'])
+                ts = r['gen_ts']
+                row.append(age(ct,ts))
+            else:
+                row.append('')
         except:
-            row.append('Unknown')
+            row.append('')
 
         output_res.append(row)
 

--- a/omg/cmd/get/job_out.py
+++ b/omg/cmd/get/job_out.py
@@ -1,0 +1,52 @@
+from tabulate import tabulate
+
+from omg.common.helper import age, age2
+
+
+def job_out(t, ns, res, output, show_type):
+    output_res=[[]]
+    # header
+    if ns == '_all':
+        output_res[0].append('NAMESPACE')
+    output_res[0].extend(['NAME','COMPLETIONS','DURATION','AGE'])
+    # resources
+    for r in res:
+        job = r['res']
+        row = []
+        # namespace (for --all-namespaces)
+        if ns == '_all':
+            row.append(job['metadata']['namespace'])
+        # name
+        if show_type:
+            row.append(t + '/' + job['metadata']['name'])
+        else:
+            row.append(job['metadata']['name'])
+        # completions
+        try:
+            # test numerator
+            try:
+                comp_num = str(job['status']['succeeded'])
+            except:
+                comp_num = '0'
+            # append denominator
+            comp_den = str(job['spec']['completions'])
+            row.append(comp_num + '/' + comp_den)
+        except:
+            row.append('??')
+        # duration
+        try:
+            st = str(job['status']['startTime'])
+            ct = str(job['status']['completionTime'])
+            row.append(age2(st,ct))
+        except:
+            row.append('Unknown')
+        # age
+        try:
+            ct = str(job['status']['startTime'])
+            ts = r['gen_ts']
+            row.append(age(ct,ts))
+        except:
+            row.append('Unknown')
+        output_res.append(row)
+
+    print(tabulate(output_res,tablefmt="plain"))

--- a/omg/cmd/get/rc_out.py
+++ b/omg/cmd/get/rc_out.py
@@ -1,0 +1,59 @@
+from tabulate import tabulate
+
+from omg.common.helper import age
+
+
+def rc_out(t, ns, res, output, show_type):
+    output_res=[[]]
+    # header
+    if ns == '_all':
+        output_res[0].append('NAMESPACE')
+    output_res[0].extend(['NAME','DESIRED','CURRENT','READY','AGE'])
+    if output == 'wide':
+        output_res[0].extend(['CONTAINERS','IMAGES'])
+    # resources
+    for r in res:
+        rc = r['res']
+        row = []
+        # namespace (for --all-namespaces)
+        if ns == '_all':
+            row.append(rc['metadata']['namespace'])
+        # name
+        if show_type:
+            row.append(t + '/' + rc['metadata']['name'])
+        else:
+            row.append(rc['metadata']['name'])
+        # desired
+        try:
+            row.append(rc['status']['replicas'])
+        except:
+            row.append('0')
+        # current
+        try:
+            row.append(rc['status']['fullyLabeledReplicas'])
+        except:
+            row.append('0')
+        # ready
+        try:
+            row.append(rc['status']['readyReplicas'])
+        except:
+            row.append('0')
+        # age
+        try:
+            ct = str(rc['metadata']['creationTimestamp'])
+            ts = r['gen_ts']
+            row.append(age(ct,ts))
+        except:
+            row.append('Unknown')
+        # -o wide
+        if output == 'wide':
+            # container:
+            conts = [ c['name'] for c in rc['spec']['template']['spec']['containers'] ]
+            row.append(','.join(conts))
+            # images:
+            images = [ c['image'] for c in rc['spec']['template']['spec']['containers'] ]
+            row.append(','.join(images))
+
+        output_res.append(row)
+
+    print(tabulate(output_res,tablefmt="plain"))

--- a/omg/cmd/get/sc_out.py
+++ b/omg/cmd/get/sc_out.py
@@ -3,9 +3,9 @@ from tabulate import tabulate
 from omg.common.helper import age
 
 def sc_out(t, ns, res, output, show_type):
-    output_res=[[]]
+    output_res=[]
     # header
-    output_res[0].extend(['NAME','PROVISIONER','RECLAIMPOLICY','VOLUMEBINDINGMODE','ALLOWVOLUMEEXPANSION','AGE'])
+    header = ['NAME','PROVISIONER','RECLAIMPOLICY','VOLUMEBINDINGMODE','ALLOWVOLUMEEXPANSION','AGE']
     # resources
     for r in res:
         sc = r['res']
@@ -36,4 +36,7 @@ def sc_out(t, ns, res, output, show_type):
 
         output_res.append(row)
 
-    print(tabulate(output_res,tablefmt="plain"))
+    # sort by 1st column
+    sorted_output = sorted(output_res)
+    sorted_output.insert(0,header)
+    print(tabulate(sorted_output,tablefmt="plain"))

--- a/omg/cmd/get_main.py
+++ b/omg/cmd/get_main.py
@@ -35,7 +35,6 @@ def get_main(a):
     # e.g, for `get pod,svc` this will look like:
     #   objects = { 'pod': ['_all'], 'service': ['_all'] }
     objects = {}
-    is_all = False
 
     last_object = []
     for o in a.objects:
@@ -62,7 +61,6 @@ def get_main(a):
                 
         # Convert 'all' to list of resource types in a specific order
         elif 'all' in o:
-            is_all = True
             r_types = ['pod', 'rc', 'svc', 'ds', 'deployment', 'rs', 'statefulset', 'hpa', 'job', 'cronjob', 'dc', 'bc', 'build', 'is']
             for rt in r_types:
                 check_rt = map_res(rt)
@@ -140,11 +138,9 @@ def get_main(a):
         res = get_func(rt, ns, objects[rt], yaml_loc, need_ns)
 
         # Error out if no objects/resources were collected
-        if len(res) == 0 and is_all == False:
-            print('No resources found for type "%s" found in namespace "%s" '%(rt,ns))
-        elif len(res) == 0 and is_all == True:
-            dummy = True   # don't print anything out and skip to next resource
-        else:
+        if len(res) == 0 and len(objects) == 1:
+            print('No resources found for type "%s" in %s namespace'%(rt,ns))
+        elif len(res) > 0:
             # If printing multiple objects, add a blank line between each
             if mult_objs_blank_line == True:
                 print('')
@@ -172,3 +168,6 @@ def get_main(a):
             # Flag to print multiple objects
             if mult_objs_blank_line == False:
                 mult_objs_blank_line = True
+    # Error out once if multiple objects/resources requested and none collected
+    if mult_objs_blank_line == False and len(objects) > 1:
+        print('No resources found in %s namespace'%(ns))

--- a/omg/common/helper.py
+++ b/omg/common/helper.py
@@ -35,6 +35,29 @@ def age(obj_time, file_ts):
     else:
         return str(rd.seconds)+'s'
 
+
+def age2(obj_time, obj2_time):
+
+    try:
+        dt1 = parse(obj_time, ignoretz=True)
+        dt2 = parse(obj2_time, ignoretz=True)
+        rd = relativedelta(dt2, dt1)
+    except:
+        return 'Unknown'
+
+    if rd.days > 0:
+        return str(rd.days)+'d'
+    elif rd.hours > 9:
+        return str(rd.hours)+'h'
+    elif rd.hours > 0 and rd.hours < 10:
+        return str(rd.hours)+'h'+str(rd.minutes)+'m'
+    elif rd.minutes > 9:
+        return str(rd.minutes) + 'm'
+    elif rd.minutes > 0 and rd.minutes < 10:
+        return str(rd.minutes)+'m'+str(rd.seconds)+'s'
+    else:
+        return str(rd.seconds)+'s'
+
 # This is a helper function to load yaml files
 # Input: yaml file path (yp)
 # Output: python dict of the yaml

--- a/omg/common/resource_map.py
+++ b/omg/common/resource_map.py
@@ -7,12 +7,14 @@ from omg.cmd.get.build_out import build_out
 from omg.cmd.get.co_out import co_out
 from omg.cmd.get.cm_out import cm_out
 from omg.cmd.get.cj_out import cj_out
+from omg.cmd.get.crd_out import crd_out
 from omg.cmd.get.csr_out import csr_out
 from omg.cmd.get.cv_out import cv_out
 from omg.cmd.get.dc_out import dc_out
 from omg.cmd.get.deployment_out import deployment_out
 from omg.cmd.get.ds_out import ds_out
 from omg.cmd.get.ep_out import ep_out
+from omg.cmd.get.eps_out import eps_out
 from omg.cmd.get.ev_out import ev_out
 from omg.cmd.get.hpa_out import hpa_out
 from omg.cmd.get.is_out import is_out
@@ -26,6 +28,8 @@ from omg.cmd.get.node_out import node_out
 from omg.cmd.get.pod_out import pod_out
 from omg.cmd.get.project_out import project_out
 from omg.cmd.get.pv_out import pv_out
+from omg.cmd.get.pvc_out import pvc_out
+from omg.cmd.get.rc_out import rc_out
 from omg.cmd.get.route_out import route_out
 from omg.cmd.get.rs_out import rs_out
 from omg.cmd.get.sc_out import sc_out
@@ -84,7 +88,7 @@ map = [
         'yaml_loc': 'namespaces/%s/batch/cronjobs.yaml' },
 
     {   'type': 'customresourcedefinition','aliases': ['customresourcedefinitions', 'crd', 'crds'],'need_ns': False,
-        'get_func': from_yaml, 'getout_func': simple_out,
+        'get_func': from_yaml, 'getout_func': crd_out,
         'yaml_loc': 'cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions' },
     
     {   'type': 'daemonset','aliases': ['daemonsets', 'ds'],'need_ns': True,
@@ -106,6 +110,10 @@ map = [
     {   'type': 'endpoint','aliases': ['endpoints', 'ep'],'need_ns': True,
         'get_func': from_yaml, 'getout_func': ep_out,
         'yaml_loc': 'namespaces/%s/core/endpoints.yaml' },
+
+    {   'type': 'endpointslice','aliases': ['endpointslices'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': eps_out,
+        'yaml_loc': 'namespaces/%s/discovery.k8s.io/endpointslices.yaml' },
 
     {   'type': 'event','aliases': ['events', 'ev'],'need_ns': True,
         'get_func': from_yaml, 'getout_func': ev_out,
@@ -131,7 +139,7 @@ map = [
         'get_func': from_yaml, 'getout_func': simple_out,
         'yaml_loc': 'cluster-scoped-resources/config.openshift.io/infrastructures.yaml' },
 
-    {   'type': 'ingress','aliases': ['ingresses'],'need_ns': False,
+    {   'type': 'ingress','aliases': ['ingresses'],'need_ns': True,
         'get_func': from_yaml, 'getout_func': simple_out,
         'yaml_loc': 'cluster-scoped-resources/config.openshift.io/ingresses.yaml' },
 
@@ -181,7 +189,7 @@ map = [
         'yaml_loc': 'cluster-scoped-resources/core/persistentvolumes' },
 
     {   'type': 'persistentvolumeclaim','aliases': ['persistentvolumeclaims', 'pvc'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': simple_out,
+        'get_func': from_yaml, 'getout_func': pvc_out,
         'yaml_loc': 'namespaces/%s/core/persistentvolumeclaims.yaml' },
         
     {   'type': 'pod','aliases': ['pods', 'po'],'need_ns': True,
@@ -201,7 +209,7 @@ map = [
         'yaml_loc': 'namespaces/%s/apps/replicasets.yaml' },
 
     {   'type': 'replicationcontroller','aliases': ['replicationcontrollers', 'rc'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': simple_out,
+        'get_func': from_yaml, 'getout_func': rc_out,
         'yaml_loc': 'namespaces/%s/core/replicationcontrollers.yaml' },
 
     {   'type': 'route','aliases': ['routes'],'need_ns': True,

--- a/omg/common/resource_map.py
+++ b/omg/common/resource_map.py
@@ -2,29 +2,35 @@ from omg.cmd.get.from_yaml import from_yaml
 from omg.cmd.get.get_project import get_project
 
 from omg.cmd.get.simple_out import simple_out
-from omg.cmd.get.node_out import node_out
-from omg.cmd.get.pod_out import pod_out
-from omg.cmd.get.project_out import project_out
+from omg.cmd.get.bc_out import bc_out
+from omg.cmd.get.build_out import build_out
 from omg.cmd.get.co_out import co_out
+from omg.cmd.get.cm_out import cm_out
+from omg.cmd.get.cj_out import cj_out
 from omg.cmd.get.csr_out import csr_out
 from omg.cmd.get.cv_out import cv_out
+from omg.cmd.get.deployment_out import deployment_out
+from omg.cmd.get.ep_out import ep_out
+from omg.cmd.get.ev_out import ev_out
+from omg.cmd.get.hpa_out import hpa_out
+from omg.cmd.get.is_out import is_out
+from omg.cmd.get.job_out import job_out
+from omg.cmd.get.machine_out import machine_out
+from omg.cmd.get.machineset_out import machineset_out
 from omg.cmd.get.mcp_out import mcp_out
 from omg.cmd.get.mc_out import mc_out
 from omg.cmd.get.mwhc_out import mwhc_out
+from omg.cmd.get.node_out import node_out
+from omg.cmd.get.pod_out import pod_out
+from omg.cmd.get.project_out import project_out
 from omg.cmd.get.pv_out import pv_out
+from omg.cmd.get.route_out import route_out
+from omg.cmd.get.rs_out import rs_out
 from omg.cmd.get.sc_out import sc_out
 from omg.cmd.get.secret_out import secret_out
 from omg.cmd.get.service_out import service_out
-from omg.cmd.get.route_out import route_out
-from omg.cmd.get.cm_out import cm_out
-from omg.cmd.get.ep_out import ep_out
-from omg.cmd.get.ev_out import ev_out
-from omg.cmd.get.deployment_out import deployment_out
-from omg.cmd.get.rs_out import rs_out
 from omg.cmd.get.ss_out import ss_out
 from omg.cmd.get.vwhc_out import vwhc_out
-from omg.cmd.get.machine_out import machine_out
-from omg.cmd.get.machineset_out import machineset_out
 
 
 # This map and function normalizes/standarizes the different names of object/resources types
@@ -34,78 +40,6 @@ from omg.cmd.get.machineset_out import machineset_out
 
 
 map = [
-    {   'type': 'pod','aliases': ['pods', 'po'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': pod_out,
-        'yaml_loc': 'namespaces/%s/core/pods.yaml' },
-
-    {   'type': 'service','aliases': ['services', 'svc'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': service_out,
-        'yaml_loc': 'namespaces/%s/core/services.yaml' },
-
-    {   'type': 'secret','aliases': ['secrets'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': secret_out,
-        'yaml_loc': 'namespaces/%s/core/secrets.yaml' },
-
-    {   'type': 'configmap','aliases': ['configmaps', 'cm'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': cm_out,
-        'yaml_loc': 'namespaces/%s/core/configmaps.yaml' },
-
-    {   'type': 'endpoint','aliases': ['endpoints', 'ep'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': ep_out,
-        'yaml_loc': 'namespaces/%s/core/endpoints.yaml' },
-
-    {   'type': 'event','aliases': ['events', 'ev'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': ev_out,
-        'yaml_loc': 'namespaces/%s/core/events.yaml' },
-
-    {   'type': 'persistentvolumeclaim','aliases': ['persistentvolumeclaims', 'pvc'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': simple_out,
-        'yaml_loc': 'namespaces/%s/core/persistentvolumeclaims.yaml' }, ###
-
-    {   'type': 'replicationcontroller','aliases': ['replicationcontrollers', 'rc'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': simple_out,
-        'yaml_loc': 'namespaces/%s/core/replicationcontrollers.yaml' }, ###
-
-    {   'type': 'replicaset','aliases': ['replicasets', 'rs'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': rs_out,
-        'yaml_loc': 'namespaces/%s/apps/replicasets.yaml' },
-
-    {   'type': 'statefulset','aliases': ['statefulsets'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': ss_out,
-        'yaml_loc': 'namespaces/%s/apps/statefulsets.yaml' }, ###
-
-    {   'type': 'deployment','aliases': ['deployments'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': deployment_out,
-        'yaml_loc': 'namespaces/%s/apps/deployments.yaml' },
-    
-    {   'type': 'daemonset','aliases': ['daemonsets', 'ds'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': simple_out,
-        'yaml_loc': 'namespaces/%s/apps/daemonsets.yaml' }, ###
-
-    {   'type': 'deploymentconfig','aliases': ['deploymentconfigs', 'dc'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': simple_out,
-        'yaml_loc': 'namespaces/%s/apps.openshift.io/deploymentconfigs.yaml' }, ###
-
-    {   'type': 'route','aliases': ['routes'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': route_out,
-        'yaml_loc': 'namespaces/%s/route.openshift.io/routes.yaml' }, ###
-
-    {   'type': 'node','aliases': ['nodes'],'need_ns': False,
-        'get_func': from_yaml, 'getout_func': node_out,
-        'yaml_loc': 'cluster-scoped-resources/core/nodes' },
-        # When yaml_loc is a dir like in this case, we scan *.yaml files in it.
-
-    {   'type': 'persistentvolume','aliases': ['persistentvolumes', 'pv'],'need_ns': False,
-        'get_func': from_yaml, 'getout_func': pv_out,
-        'yaml_loc': 'cluster-scoped-resources/core/persistentvolumes' },
-
-    {   'type': 'machineconfigpool','aliases': ['machineconfigpools', 'mcp'],'need_ns': False,
-        'get_func': from_yaml, 'getout_func': mcp_out,
-        'yaml_loc': 'cluster-scoped-resources/machineconfiguration.openshift.io/machineconfigpools' },
-
-    {   'type': 'machineconfig','aliases': ['machineconfigs', 'mc'],'need_ns': False,
-        'get_func': from_yaml, 'getout_func': mc_out,
-        'yaml_loc': 'cluster-scoped-resources/machineconfiguration.openshift.io/machineconfigs' },
 
     {   'type': 'apiserver','aliases': ['apiservers'],'need_ns': False,
         'get_func': from_yaml, 'getout_func': simple_out,
@@ -115,6 +49,18 @@ map = [
         'get_func': from_yaml, 'getout_func': simple_out,
         'yaml_loc': 'cluster-scoped-resources/config.openshift.io/authentications.yaml' },
 
+    {   'type': 'build','aliases': ['builds'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': build_out,
+        'yaml_loc': 'namespaces/%s/build.openshift.io/builds.yaml' },
+    
+    {   'type': 'buildconfig','aliases': ['buildconfigs', 'bc'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': bc_out,
+        'yaml_loc': 'namespaces/%s/build.openshift.io/buildconfigs.yaml' },
+
+    {   'type': 'certificatesigningrequest','aliases': ['certificatesigningrequests', 'csr'],'need_ns': False,
+        'get_func': from_yaml, 'getout_func': csr_out,
+        'yaml_loc': 'cluster-scoped-resources/certificates.k8s.io/certificatesigningrequests' },
+        
     {   'type': 'clusteroperator','aliases': ['clusteroperators', 'co'],'need_ns': False,
         'get_func': from_yaml, 'getout_func': co_out,
         'yaml_loc': 'cluster-scoped-resources/config.openshift.io/clusteroperators.yaml' },
@@ -123,25 +69,61 @@ map = [
         'get_func': from_yaml, 'getout_func': cv_out,
         'yaml_loc': 'cluster-scoped-resources/config.openshift.io/clusterversions.yaml' },
 
+    {   'type': 'configmap','aliases': ['configmaps', 'cm'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': cm_out,
+        'yaml_loc': 'namespaces/%s/core/configmaps.yaml' },
+
     {   'type': 'console','aliases': ['consoles'],'need_ns': False,
         'get_func': from_yaml, 'getout_func': simple_out,
         'yaml_loc': 'cluster-scoped-resources/config.openshift.io/consoles.yaml' },
 
-    {   'type': 'certificatesigningrequest','aliases': ['certificatesigningrequests', 'csr'],'need_ns': False,
-        'get_func': from_yaml, 'getout_func': csr_out,
-        'yaml_loc': 'cluster-scoped-resources/certificates.k8s.io/certificatesigningrequests' },
+    {   'type': 'cronjob','aliases': ['cronjobs'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': cj_out,
+        'yaml_loc': 'namespaces/%s/batch/cronjobs.yaml' },
+
+    {   'type': 'customresourcedefinition','aliases': ['customresourcedefinitions', 'crd', 'crds'],'need_ns': False,
+        'get_func': from_yaml, 'getout_func': simple_out,
+        'yaml_loc': 'cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions' },
+    
+    {   'type': 'daemonset','aliases': ['daemonsets', 'ds'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': simple_out,
+        'yaml_loc': 'namespaces/%s/apps/daemonsets.yaml' },
+        
+    {   'type': 'deployment','aliases': ['deployments'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': deployment_out,
+        'yaml_loc': 'namespaces/%s/apps/deployments.yaml' },
+
+    {   'type': 'deploymentconfig','aliases': ['deploymentconfigs', 'dc'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': simple_out,
+        'yaml_loc': 'namespaces/%s/apps.openshift.io/deploymentconfigs.yaml' },
 
     {   'type': 'dns','aliases': ['dnses'],'need_ns': False,
         'get_func': from_yaml, 'getout_func': simple_out,
         'yaml_loc': 'cluster-scoped-resources/config.openshift.io/dnses.yaml' },
 
+    {   'type': 'endpoint','aliases': ['endpoints', 'ep'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': ep_out,
+        'yaml_loc': 'namespaces/%s/core/endpoints.yaml' },
+
+    {   'type': 'event','aliases': ['events', 'ev'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': ev_out,
+        'yaml_loc': 'namespaces/%s/core/events.yaml' },
+
     {   'type': 'featuregate','aliases': ['featuregates'],'need_ns': False,
         'get_func': from_yaml, 'getout_func': simple_out,
         'yaml_loc': 'cluster-scoped-resources/config.openshift.io/featuregates.yaml' },
 
+    {   'type': 'horizontalpodautoscaler','aliases': ['horizontalpodautoscalers', 'hpa'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': hpa_out,
+        'yaml_loc': 'namespaces/%s/autoscaling/horizontalpodautoscalers.yaml' },
+
     {   'type': 'image','aliases': ['images'],'need_ns': False,
         'get_func': from_yaml, 'getout_func': simple_out,
         'yaml_loc': 'cluster-scoped-resources/config.openshift.io/images.yaml' },
+
+    {   'type': 'imagestream','aliases': ['imagestreams','is'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': is_out,
+        'yaml_loc': 'namespaces/%s/image.openshift.io/imagestreams.yaml' },
 
     {   'type': 'infrastructure','aliases': ['infrastructures'],'need_ns': False,
         'get_func': from_yaml, 'getout_func': simple_out,
@@ -151,13 +133,38 @@ map = [
         'get_func': from_yaml, 'getout_func': simple_out,
         'yaml_loc': 'cluster-scoped-resources/config.openshift.io/ingresses.yaml' },
 
+    {   'type': 'job','aliases': ['jobs'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': job_out,
+        'yaml_loc': 'namespaces/%s/batch/jobs.yaml' },
+
+    {   'type': 'machine','aliases': ['machines'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': machine_out,
+        'yaml_loc': 'namespaces/%s/machine.openshift.io/machines' },
+
+    {   'type': 'machineconfig','aliases': ['machineconfigs', 'mc'],'need_ns': False,
+        'get_func': from_yaml, 'getout_func': mc_out,
+        'yaml_loc': 'cluster-scoped-resources/machineconfiguration.openshift.io/machineconfigs' },
+
+    {   'type': 'machineconfigpool','aliases': ['machineconfigpools', 'mcp'],'need_ns': False,
+        'get_func': from_yaml, 'getout_func': mcp_out,
+        'yaml_loc': 'cluster-scoped-resources/machineconfiguration.openshift.io/machineconfigpools' },
+
+    {   'type': 'machineset','aliases': ['machinesets'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': machineset_out,
+        'yaml_loc': 'namespaces/%s/machine.openshift.io/machinesets' },
+
     {   'type': 'mutatingwebhookconfiguration','aliases': ['mutatingwebhookconfigurations'],'need_ns': False,
         'get_func': from_yaml, 'getout_func': mwhc_out,
         'yaml_loc': 'cluster-scoped-resources/admissionregistration.k8s.io/mutatingwebhookconfigurations' },
-
+        
     {   'type': 'network','aliases': ['networks'],'need_ns': False,
         'get_func': from_yaml, 'getout_func': simple_out,
         'yaml_loc': 'cluster-scoped-resources/config.openshift.io/networks.yaml' },
+
+    {   'type': 'node','aliases': ['nodes'],'need_ns': False,
+        'get_func': from_yaml, 'getout_func': node_out,
+        'yaml_loc': 'cluster-scoped-resources/core/nodes' },
+        # When yaml_loc is a dir like in this case, we scan *.yaml files in it.
 
     {   'type': 'oauth','aliases': ['oauths'],'need_ns': False,
         'get_func': from_yaml, 'getout_func': simple_out,
@@ -166,6 +173,18 @@ map = [
     {   'type': 'operatorhub','aliases': ['operatorhubs'],'need_ns': False,
         'get_func': from_yaml, 'getout_func': simple_out,
         'yaml_loc': 'cluster-scoped-resources/config.openshift.io/operatorhubs.yaml' },
+        
+    {   'type': 'persistentvolume','aliases': ['persistentvolumes', 'pv'],'need_ns': False,
+        'get_func': from_yaml, 'getout_func': pv_out,
+        'yaml_loc': 'cluster-scoped-resources/core/persistentvolumes' },
+
+    {   'type': 'persistentvolumeclaim','aliases': ['persistentvolumeclaims', 'pvc'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': simple_out,
+        'yaml_loc': 'namespaces/%s/core/persistentvolumeclaims.yaml' },
+        
+    {   'type': 'pod','aliases': ['pods', 'po'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': pod_out,
+        'yaml_loc': 'namespaces/%s/core/pods.yaml' },
 
     {   'type': 'project','aliases': ['projects'],'need_ns': False,
         'get_func': get_project, 'getout_func': project_out,
@@ -175,9 +194,33 @@ map = [
         'get_func': from_yaml, 'getout_func': simple_out,
         'yaml_loc': 'cluster-scoped-resources/config.openshift.io/proxies.yaml' },
 
+    {   'type': 'replicaset','aliases': ['replicasets', 'rs'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': rs_out,
+        'yaml_loc': 'namespaces/%s/apps/replicasets.yaml' },
+
+    {   'type': 'replicationcontroller','aliases': ['replicationcontrollers', 'rc'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': simple_out,
+        'yaml_loc': 'namespaces/%s/core/replicationcontrollers.yaml' },
+
+    {   'type': 'route','aliases': ['routes'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': route_out,
+        'yaml_loc': 'namespaces/%s/route.openshift.io/routes.yaml' },
+
     {   'type': 'scheduler','aliases': ['schedulers'],'need_ns': False,
         'get_func': from_yaml, 'getout_func': simple_out,
         'yaml_loc': 'cluster-scoped-resources/config.openshift.io/schedulers.yaml' },
+
+    {   'type': 'secret','aliases': ['secrets'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': secret_out,
+        'yaml_loc': 'namespaces/%s/core/secrets.yaml' },
+
+    {   'type': 'service','aliases': ['services', 'svc'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': service_out,
+        'yaml_loc': 'namespaces/%s/core/services.yaml' },
+
+    {   'type': 'statefulset','aliases': ['statefulsets'],'need_ns': True,
+        'get_func': from_yaml, 'getout_func': ss_out,
+        'yaml_loc': 'namespaces/%s/apps/statefulsets.yaml' },
 
     {   'type': 'storageclass','aliases': ['storageclasses', 'sc'],'need_ns': False,
         'get_func': from_yaml, 'getout_func': sc_out,
@@ -186,18 +229,6 @@ map = [
     {   'type': 'validatingwebhookconfiguration','aliases': ['validatingwebhookconfigurations'],'need_ns': False,
         'get_func': from_yaml, 'getout_func': vwhc_out,
         'yaml_loc': 'cluster-scoped-resources/admissionregistration.k8s.io/validatingwebhookconfigurations' },
-
-    {   'type': 'machineset','aliases': ['machinesets'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': machineset_out,
-        'yaml_loc': 'namespaces/%s/machine.openshift.io/machinesets' },
-
-    {   'type': 'machine','aliases': ['machines'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': machine_out,
-        'yaml_loc': 'namespaces/%s/machine.openshift.io/machines' },
-
-    {   'type': 'customresourcedefinition','aliases': ['customresourcedefinitions', 'crd', 'crds'],'need_ns': False,
-        'get_func': from_yaml, 'getout_func': simple_out,
-        'yaml_loc': 'cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions' },
 
 ]
 

--- a/omg/common/resource_map.py
+++ b/omg/common/resource_map.py
@@ -9,7 +9,9 @@ from omg.cmd.get.cm_out import cm_out
 from omg.cmd.get.cj_out import cj_out
 from omg.cmd.get.csr_out import csr_out
 from omg.cmd.get.cv_out import cv_out
+from omg.cmd.get.dc_out import dc_out
 from omg.cmd.get.deployment_out import deployment_out
+from omg.cmd.get.ds_out import ds_out
 from omg.cmd.get.ep_out import ep_out
 from omg.cmd.get.ev_out import ev_out
 from omg.cmd.get.hpa_out import hpa_out
@@ -86,7 +88,7 @@ map = [
         'yaml_loc': 'cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions' },
     
     {   'type': 'daemonset','aliases': ['daemonsets', 'ds'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': simple_out,
+        'get_func': from_yaml, 'getout_func': ds_out,
         'yaml_loc': 'namespaces/%s/apps/daemonsets.yaml' },
         
     {   'type': 'deployment','aliases': ['deployments'],'need_ns': True,
@@ -94,7 +96,7 @@ map = [
         'yaml_loc': 'namespaces/%s/apps/deployments.yaml' },
 
     {   'type': 'deploymentconfig','aliases': ['deploymentconfigs', 'dc'],'need_ns': True,
-        'get_func': from_yaml, 'getout_func': simple_out,
+        'get_func': from_yaml, 'getout_func': dc_out,
         'yaml_loc': 'namespaces/%s/apps.openshift.io/deploymentconfigs.yaml' },
 
     {   'type': 'dns','aliases': ['dnses'],'need_ns': False,


### PR DESCRIPTION
This PR implements `oc get all`, which prints the following resources in the namespace.  To implement this, I also subsequently implemented the missing resources.
- pod
- replicationcontroller
- service
- daemonset
- deployment
- replicaset
- statefulset
- horizontalpodautoscaler **(NEW)**
- job **(NEW)**
- cronjob **(NEW)**
- deploymentconfig
- buildconfig **(NEW)**
- build **(NEW)**
- imagestream **(NEW)**

I also implemented an age2() utility function in `common/helper.py` which compares two timestamps (rather than a timestamp and unix epoch timestamp), and used this in `cmd/get/job_out.py`.

I refactored `cmd/get_main.py` a fair amount, so it's worth a review.

And finally, I sorted the resources in `common/resource_map.py` alphabetically, since we have a rather large list now.