### PR TITLE
Suppress YAML parse warnings for autocomplete

### DIFF
--- a/omg/cmd/get/from_yaml.py
+++ b/omg/cmd/get/from_yaml.py
@@ -1,16 +1,17 @@
-import sys, os, yaml
+import sys, os
 
 from omg.common.config import Config
 from omg.common.helper import load_yaml_file
 
 # This function finds the respective yamls and returns the resouces that match
-def from_yaml(ns, names, yaml_loc, need_ns):
+def from_yaml(ns, names, yaml_loc, need_ns, print_warnings=True):
     mg_path = Config().path
     yaml_path = os.path.join(mg_path, yaml_loc)
     if need_ns:
         # Error out if it needs ns and its not set.
         if ns is None:
-            print("[ERROR] Namespace not set. Select a project (omg project) or specify a namespace (-n)")
+            if print_warnings:
+                print("[ERROR] Namespace not set. Select a project (omg project) or specify a namespace (-n)")
             sys.exit(1)
         # Get all namespace names if we need all
         elif ns == '_all':
@@ -40,9 +41,10 @@ def from_yaml(ns, names, yaml_loc, need_ns):
         try:
             # record when was this yaml generated (to calc age)
             gen_ts = os.path.getmtime(yp)
-            res = load_yaml_file(yp)
+            res = load_yaml_file(yp, print_warnings)
         except:
-            print("[ERROR] Could not read file:", yp)
+            if print_warnings:
+                print("[ERROR] Could not read file:", yp)
             sys.exit(1)
 
         # add objects to collected if name matches

--- a/omg/cmd/get/get_project.py
+++ b/omg/cmd/get/get_project.py
@@ -19,7 +19,7 @@ def get_project(ns, names, yaml_loc, need_ns):
         try:
             # record when was this yaml generated (to calc age)
             gen_ts = os.path.getmtime(yp)
-            res = load_yaml_file(yp)
+            res = load_yaml_file(yp, True)
         except:
             print("[ERROR] Could not read file:", yp)
             sys.exit(1)

--- a/omg/cmd/get_main.py
+++ b/omg/cmd/get_main.py
@@ -7,16 +7,16 @@ from omg.common.config import Config
 from omg.common.resource_map import map_res, map
 from omg.cmd.get import parse
 
-def get_resources(r_type, r_name='_all', ns=None):
+def get_resources(r_type, r_name='_all', ns=None, print_warnings=True):
     rt_info = map_res(r_type)
     get_func = rt_info['get_func']
     yaml_loc = rt_info['yaml_loc']
     need_ns = rt_info['need_ns']
 
-    return get_func(ns, r_name, yaml_loc, need_ns)
+    return get_func(ns, r_name, yaml_loc, need_ns, print_warnings)
 
 def get_resource_names(r_type, r_name='_all', ns=None):
-    res = get_resources(r_type, r_name, ns)
+    res = get_resources(r_type, r_name, ns, False)
     res_names = [ r['res']['metadata']['name'] for r in res ]
     return res_names
 

--- a/omg/common/helper.py
+++ b/omg/common/helper.py
@@ -52,7 +52,7 @@ def age(ts1, ts2, ts1_type='iso', ts2_type='epoch'):
 # at the end causing the yaml.safe_load() to error out.
 # so if the first loading attempt fails, we will
 # try to skip lines from the end and try to load the yaml
-def load_yaml_file(yp):
+def load_yaml_file(yp, print_warnings):
     import yaml
     from click import echo
     try:
@@ -79,13 +79,15 @@ def load_yaml_file(yp):
                 lines_skipped += 1
                 try:
                     res = yaml.load(yd, Loader=SafeLoader)
-                    echo("[WARN] Skipped " +
-                        str(lines_skipped) + "/" + str(lines_total) +
-                        " lines from the end of " + os.path.basename(yp) +
-                        " to the load the yaml file properly",err=True)
+                    if print_warnings:
+                        echo("[WARN] Skipped " +
+                            str(lines_skipped) + "/" + str(lines_total) +
+                            " lines from the end of " + os.path.basename(yp) +
+                            " to the load the yaml file properly",err=True)
                     return res
                 except:
                     pass
             # Skipping lines from the bottom didn't help. Error out
-            print("[ERROR] Invalid yaml file. Parsing error in ", yp)
+            if print_warnings:
+                print("[ERROR] Invalid yaml file. Parsing error in ", yp)
             sys.exit(1)


### PR DESCRIPTION
This will resolve the following issue when trying to use bash completion:

```
$ omg get nodes *TAB* [WARN] Skipped 2/418 lines from the end of master-0.example.com.yaml to the load the yaml file properly
```