### PR TITLE
omg get networkpolicy

### DIFF
--- a/omg/cmd/get/np_out.py
+++ b/omg/cmd/get/np_out.py
@@ -32,7 +32,6 @@ def networkpolicy_out(t, ns, res, output, show_type, show_labels):
         try:
             ct = str(p["metadata"]["creationTimestamp"])
             ts = r["gen_ts"]
-            ps = str(p["metadata"]["creationTimestamp"])
             row.append(age(ct, ts))
         except:
             row.append("Unknown")       

--- a/omg/cmd/get/np_out.py
+++ b/omg/cmd/get/np_out.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from tabulate import tabulate
+
+from omg.common.helper import age
+
+
+# Simple out put with just name, podSelector and age
+def networkpolicy_out(t, ns, res, output, show_type, show_labels):
+    output_res = [[]]
+    # header
+    if ns == "_all":
+        output_res[0].append("NAMESPACE")
+    output_res[0].extend(["NAME", "POD-SELECTOR", "AGE"])
+    # resources
+    for r in res:
+        p = r["res"]
+        row = []
+        # namespace (for --all-namespaces)
+        if ns == "_all":
+            row.append(p["metadata"]["namespace"])
+        # name
+        if show_type:
+            row.append(t + "/" + p["metadata"]["name"])
+        else:
+            row.append(p["metadata"]["name"])
+        # podSelector
+        try:
+            row.append(str(p["spec"]["podSelector"]))
+        except:
+            row.append("Unknown") 
+        # age
+        try:
+            ct = str(p["metadata"]["creationTimestamp"])
+            ts = r["gen_ts"]
+            ps = str(p["metadata"]["creationTimestamp"])
+            row.append(age(ct, ts))
+        except:
+            row.append("Unknown")       
+
+        output_res.append(row)
+
+    print(tabulate(output_res, tablefmt="plain"))

--- a/omg/common/resource_map.py
+++ b/omg/common/resource_map.py
@@ -26,6 +26,7 @@ from omg.cmd.get.mc_out import mc_out
 from omg.cmd.get.mcp_out import mcp_out
 from omg.cmd.get.mwhc_out import mwhc_out
 from omg.cmd.get.node_out import node_out
+from omg.cmd.get.np_out import networkpolicy_out
 from omg.cmd.get.pod_out import pod_out
 from omg.cmd.get.project_out import project_out
 from omg.cmd.get.pv_out import pv_out
@@ -295,6 +296,14 @@ map = [
         "get_func": from_yaml,
         "getout_func": simple_out,
         "yaml_loc": "cluster-scoped-resources/config.openshift.io/networks.yaml",
+    },
+    {
+        "type": "networkpolicy",
+        "aliases": ["networkpolicies"],
+        "need_ns": True,
+        "get_func": from_yaml,
+        "getout_func": networkpolicy_out,
+        "yaml_loc": "namespaces/%s/networking.k8s.io/networkpolicies",
     },
     {
         "type": "node",


### PR DESCRIPTION
Hi Kxr,

I have added the function to get all (or one) NetworkPolicy.

-----

$ omg get networkpolicy -A

NAMESPACE                       NAME                          POD-SELECTOR  AGE
app-template                    allow-from-default-namespace  {}            46d
app-template                    allow-from-same-namespace     {}            46d

$ omg get networkpolicy -n app-template  allow-from-same-namespace -o yaml

apiVersion: networking.k8s.io/v1    
kind: NetworkPolicy     
metadata:    
  creationTimestamp: '2021-04-26T14:34:32Z'
  generation: 1      
  managedFields:         
  - apiVersion: networking.k8s.io/v1
    fieldsType: FieldsV1
    fieldsV1:                   
      f:spec:                    
        f:ingress: {}    
        f:policyTypes: {}   
    manager: openshift-apiserver                                                                                                          
    operation: Update                      
    time: '2021-04-26T14:34:32Z'
  name: allow-from-same-namespace
  namespace: app-template
  resourceVersion: '3359803'
  selfLink: /apis/networking.k8s.io/v1/namespaces/app-template/networkpolicies/allow-from-same-namespace
  uid: 543614e0-88fd-4189-b69c-6e5fb76c2982
spec:
  ingress:                                      
  - from:
    - podSelector: {}
  podSelector: {}
  policyTypes: [Ingress]