### PR TITLE
feat/session : another way to use must-gather files

### DIFF
--- a/omg/cli.py
+++ b/omg/cli.py
@@ -42,7 +42,7 @@ def cli():
     type=click.Path(exists=True, file_okay=False, resolve_path=True, allow_dash=False),
 )
 @click.option("--cwd", is_flag=True)
-@click.option("--session", "-s")
+@click.option("--session", "-s", is_flag=True, type=bool, help="Use session file config.")
 def use_cmd(mg_path, cwd, session):
     """
     Select the must-gather to use

--- a/omg/cli.py
+++ b/omg/cli.py
@@ -42,11 +42,12 @@ def cli():
     type=click.Path(exists=True, file_okay=False, resolve_path=True, allow_dash=False),
 )
 @click.option("--cwd", is_flag=True)
-def use_cmd(mg_path, cwd):
+@click.option("--session", "-s")
+def use_cmd(mg_path, cwd, session):
     """
     Select the must-gather to use
     """
-    use(mg_path, cwd)
+    use(mg_path, cwd, session)
 
 
 @cli.command("project")

--- a/omg/cmd/use.py
+++ b/omg/cmd/use.py
@@ -4,57 +4,86 @@ import os
 from omg.common.config import Config
 
 
-def use(mg_path, cwd):
-    if mg_path is None:
-        if cwd is True:
-            # If --cwd is set we will blindly assume current working directory
-            # to be the must-gather to use
-            c = Config(fail_if_no_path=False)
-            c.save(path=".")
-            print("Using your current working directory")
-        else:
-            # If no args are passed after `omg use`
-            # we print the info about currently selected must-gather
-            path = Config().path
-            project = Config().project
-            print("Current must-gather: %s" % path)
-            print("    Current Project: %s" % project)
-            try:
-                from omg.cmd.get_main import get_resources
+def use_cwd():
+    # If --cwd is set we will blindly assume current working directory
+    # to be the must-gather to use
+    c = Config(fail_if_no_path=False)
+    c.save(path='.')
+    print("Using your current working directory")
 
-                infra = get_resources("Infrastructure")
-                apiServerURL = [i["res"]["status"]["apiServerURL"] for i in infra]
-                platform = [i["res"]["status"]["platform"] for i in infra]
-                print("    Cluster API URL: %s" % str(apiServerURL))
-                print("   Cluster Platform: %s" % str(platform))
-            except:
-                print("[ERROR] Unable to determine cluster API URL and Platform.")
-    else:
-        c = Config(fail_if_no_path=False)
-        p = mg_path
-        # We traverse up to 3 levels to find the must-gather
-        # At each leve if it has only one dir and we check inside it
-        # When we see see the dir /namespaces and /cluster-scoped-resources, we assume it
-        for _ in [1, 2, 3]:
-            if os.path.isdir(p):
-                dirs = [d for d in os.listdir(p) if os.path.isdir(os.path.join(p, d))]
-                if "namespaces" in dirs or "cluster-scoped-resources" in dirs:
-                    full_path = os.path.abspath(p)
-                    c.save(path=full_path)
-                    print("Using: ", p)
-                    break
-                elif len(dirs) == 1:
-                    p = os.path.join(p, dirs[0])
-                elif len(dirs) > 1:
-                    print("[ERROR] Multiple directories found:", dirs)
-                    break
-                else:
-                    print(
-                        "[ERROR] Invalid must-gather path. Please point to the extracted must-gather directory"
-                    )
-                    break
-            else:
-                print(
-                    "[ERROR] Invalid path. Please give path to the extracted must-gather"
-                )
+
+def use_current_cfg():
+    # If no args are passed after `omg use`
+    # we print the info about currently selected must-gather
+    path = Config().path
+    project = Config().project
+    print('Current must-gather: %s' % path)
+    print('    Current Project: %s' % project)
+    try:
+        from omg.cmd.get_main import get_resources
+        infra = get_resources('Infrastructure')
+        apiServerURL = [ i['res']['status']['apiServerURL'] for i in infra ]
+        platform = [ i['res']['status']['platform'] for i in infra ]
+        print('    Cluster API URL: %s' % str(apiServerURL))
+        print('   Cluster Platform: %s' % str(platform))
+    except:
+        print('[ERROR] Unable to determine cluster API URL and Platform.')
+
+
+def use_setup_path(mg_path):
+    # setup using file path
+    c = Config(fail_if_no_path=False)
+    p = mg_path
+    # We traverse up to 3 levels to find the must-gather
+    # At each leve if it has only one dir and we check inside it
+    # When we see see the dir /namespaces and /cluster-scoped-resources, we assume it
+    for _ in [1,2,3]:
+        if os.path.isdir(p):
+            dirs = [d for d in os.listdir(p) if os.path.isdir(os.path.join(p,d))]
+            if 'namespaces' in dirs or 'cluster-scoped-resources' in dirs:
+                full_path = os.path.abspath(p)
+                c.save(path=full_path)
+                print('Using: ',p)
                 break
+            elif len(dirs) == 1:
+                p = os.path.join(p,dirs[0])
+            elif len(dirs) > 1:
+                print('[ERROR] Multiple directories found:', dirs)
+                break
+            else:
+                print('[ERROR] Invalid must-gather path. Please point to the extracted must-gather directory')
+                break
+        else:
+            print('[ERROR] Invalid path. Please give path to the extracted must-gather')
+            break
+
+
+def use_session(session, mg_path=None):
+    if mg_path:
+        print(f"[TODO] setup a new session {session} to path {mg_path}")
+        return
+
+    print(f"[TODO] retrieve current session {session}")
+    return
+
+
+def use(mg_path, cwd, session):
+    """
+    use (--cmd|--session s_name mg_path)
+    use will setup a working directory. When session is defined
+    a new session will be saved on Config, otherwise the default
+    will be set.
+    """
+    if mg_path is None:
+        if cwd == True:
+            return use_cwd()
+
+        if session:
+            return use_session(session)
+
+        return use_current_cfg()
+
+    if session:
+        return use_session(session, mg_path=mg_path)
+
+    return use_setup_path(mg_path)

--- a/omg/cmd/use.py
+++ b/omg/cmd/use.py
@@ -4,86 +4,59 @@ import os
 from omg.common.config import Config
 
 
-def use_cwd():
-    # If --cwd is set we will blindly assume current working directory
-    # to be the must-gather to use
-    c = Config(fail_if_no_path=False)
-    c.save(path='.')
-    print("Using your current working directory")
-
-
-def use_current_cfg():
-    # If no args are passed after `omg use`
-    # we print the info about currently selected must-gather
-    path = Config().path
-    project = Config().project
-    print('Current must-gather: %s' % path)
-    print('    Current Project: %s' % project)
-    try:
-        from omg.cmd.get_main import get_resources
-        infra = get_resources('Infrastructure')
-        apiServerURL = [ i['res']['status']['apiServerURL'] for i in infra ]
-        platform = [ i['res']['status']['platform'] for i in infra ]
-        print('    Cluster API URL: %s' % str(apiServerURL))
-        print('   Cluster Platform: %s' % str(platform))
-    except:
-        print('[ERROR] Unable to determine cluster API URL and Platform.')
-
-
-def use_setup_path(mg_path):
-    # setup using file path
-    c = Config(fail_if_no_path=False)
-    p = mg_path
-    # We traverse up to 3 levels to find the must-gather
-    # At each leve if it has only one dir and we check inside it
-    # When we see see the dir /namespaces and /cluster-scoped-resources, we assume it
-    for _ in [1,2,3]:
-        if os.path.isdir(p):
-            dirs = [d for d in os.listdir(p) if os.path.isdir(os.path.join(p,d))]
-            if 'namespaces' in dirs or 'cluster-scoped-resources' in dirs:
-                full_path = os.path.abspath(p)
-                c.save(path=full_path)
-                print('Using: ',p)
-                break
-            elif len(dirs) == 1:
-                p = os.path.join(p,dirs[0])
-            elif len(dirs) > 1:
-                print('[ERROR] Multiple directories found:', dirs)
-                break
-            else:
-                print('[ERROR] Invalid must-gather path. Please point to the extracted must-gather directory')
-                break
-        else:
-            print('[ERROR] Invalid path. Please give path to the extracted must-gather')
-            break
-
-
-def use_session(session, mg_path=None):
-    if mg_path:
-        print(f"[TODO] setup a new session {session} to path {mg_path}")
-        return
-
-    print(f"[TODO] retrieve current session {session}")
-    return
-
-
 def use(mg_path, cwd, session):
-    """
-    use (--cmd|--session s_name mg_path)
-    use will setup a working directory. When session is defined
-    a new session will be saved on Config, otherwise the default
-    will be set.
-    """
     if mg_path is None:
-        if cwd == True:
-            return use_cwd()
+        if cwd is True:
+            # If --cwd is set we will blindly assume current working directory
+            # to be the must-gather to use
+            c = Config(fail_if_no_path=False, session=session)
+            c.save(path='.')
+            print("Using your current working directory")
+        else:
+            # If no args are passed after `omg use`
+            # we print the info about currently selected must-gather
+            path = Config().path
+            project = Config().project
+            print('Current must-gather: %s' % path)
+            print('    Current Project: %s' % project)
+            if Config().session:
+                print('      Using Session: %s' % Config().session)
+            try:
+                from omg.cmd.get_main import get_resources
 
-        if session:
-            return use_session(session)
-
-        return use_current_cfg()
-
-    if session:
-        return use_session(session, mg_path=mg_path)
-
-    return use_setup_path(mg_path)
+                infra = get_resources("Infrastructure")
+                apiServerURL = [i["res"]["status"]["apiServerURL"] for i in infra]
+                platform = [i["res"]["status"]["platform"] for i in infra]
+                print("    Cluster API URL: %s" % str(apiServerURL))
+                print("   Cluster Platform: %s" % str(platform))
+            except:
+                print("[ERROR] Unable to determine cluster API URL and Platform.")
+    else:
+        c = Config(fail_if_no_path=False, session=session)
+        p = mg_path
+        # We traverse up to 3 levels to find the must-gather
+        # At each leve if it has only one dir and we check inside it
+        # When we see see the dir /namespaces and /cluster-scoped-resources, we assume it
+        for _ in [1, 2, 3]:
+            if os.path.isdir(p):
+                dirs = [d for d in os.listdir(p) if os.path.isdir(os.path.join(p, d))]
+                if "namespaces" in dirs or "cluster-scoped-resources" in dirs:
+                    full_path = os.path.abspath(p)
+                    c.save(path=full_path)
+                    print("Using: ", p)
+                    break
+                elif len(dirs) == 1:
+                    p = os.path.join(p, dirs[0])
+                elif len(dirs) > 1:
+                    print("[ERROR] Multiple directories found:", dirs)
+                    break
+                else:
+                    print(
+                        "[ERROR] Invalid must-gather path. Please point to the extracted must-gather directory"
+                    )
+                    break
+            else:
+                print(
+                    "[ERROR] Invalid path. Please give path to the extracted must-gather"
+                )
+                break


### PR DESCRIPTION
Another strategy to use `use` command and avoid cd-ing over must-gather files.

Just use the option `-s|--session` and a control file will be created inside current directory. 

I've created the option `--session` to command `omg use` to work with multiple files . It is quite similar to `--cwd` option, but the session file kept saved on current directory, and avoid cd-ing into sub dirs. At the end is yet another option to use in parallel and avoid mistakes when doing some investigation in more than one MG.

Please let me know if it is useful for the project. It will not override any existing flow if the option is not set.

Thanks.

## Usage

- using session, path1
~~~
path1 $ ls -la
drwxr-xr-x. 3 user user       174 Apr 29 23:48  must-gather.local.6119026971833308185

path1 $ omg use 
Current must-gather: /path1/must-gather.local.6119026971833308185/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-824bd46089ac8c5917c55f765c5aba82612c7e1d98cd8c5a156e1c0e1cbbffc6
    Current Project: openshift-authentication-operator
      Using Session: True
    Cluster API URL: ['https://api.example1.com:6443']
   Cluster Platform: ['VSphere']

path1 $ ls -la
drwxr-xr-x. 3 user user       174 Apr 29 23:48  must-gather.local.6119026971833308185
-rw-rw-r--. 1 user user       253 May  3 01:02  .omgsession

path1 $ cat .omgsession 
path: /path1/must-gather.local.6119026971833308185/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-824bd46089ac8c5917c55f765c5aba82612c7e1d98cd8c5a156e1c0e1cbbffc6
project: openshift-authentication-operator

~~~

- using session, path2
~~~
path2 $ ls -la 

drwxrwxr-x.  3 user  user       132 Apr 27 09:36 must-gather.local.9834403368421768860

path2 $ omg use -s must-gather.local.9834403368421768860
Using:  /path2/must-gather.local.9834403368421768860/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-6bd3e2b818edb9e127a2e64746c59e798557b2afc277a15bcb7beda962dccb5

path2 $ ls -la 
drwxrwxr-x.  3 user  user       132 Apr 27 09:36 must-gather.local.2176898684860344033
-rw-rw-r--.  1 user  user       250 May  3 01:06 .omgsession

path2 $ omg use
Current must-gather: /path2/must-gather.local.2176898684860344033/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-6bd3e2b818edb9e127a2e64746c59e798557b2afc277a15bcb7beda962dccb5
    Current Project: openshift-authentication-operator
      Using Session: True
    Cluster API URL: ['https://api.example2.ar:6443']
   Cluster Platform: ['OpenStack']
~~~

- without session:
~~~
home $ ls -la

drwxrwxr-x.  3 user  user       174 Apr 26 17:40 must-gather.local.6136420888788050128

home $ omg use must-gather.local.6136420888788050128/
Using:  /home/must-gather.local.6136420888788050128/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-deb9f79154fa64bf1dd6d2b603da966d00c38f136a72815f4577afc2ab39029a

home $ omg use
Current must-gather: /home/must-gather.local.6136420888788050128/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-deb9f79154fa64bf1dd6d2b603da966d00c38f136a72815f4577afc2ab39029a
    Current Project: openshift-authentication-operator
    Cluster API URL: ['https://api.example3:6443']
   Cluster Platform: ['oVirt']

~~~