### PR TITLE
Introduce to OLM resources

### DIFF
--- a/omg/cmd/get/olm.py
+++ b/omg/cmd/get/olm.py
@@ -6,6 +6,14 @@ from omg.common.helper import age, extract_labels
 def _build_output_res(*args, fields=[]):
     """
     Build common output response header.
+
+    Helper to positional args #:
+    0: t
+    1: ns
+    2: res
+    3: output
+    4: show_type
+    5: show_labels
     """
     ns = args[1]
     show_labels = args[5]
@@ -25,14 +33,6 @@ def _build_output_res(*args, fields=[]):
 def opcsv_out(*args):
     """
     Operator ClusterServiceVersions parser.
-
-    # Positional args #:
-    # 0: t
-    # 1: ns
-    # 2: res
-    # 3: output
-    # 4: show_type
-    # 5: show_labels
     """
     ns = args[1]
     show_labels = args[5]
@@ -105,10 +105,6 @@ def opip_out(*args):
             output_res.append(row)
 
     print(tabulate(output_res, tablefmt="plain"))
-
-
-def op_out(*args):
-    print("TODO")
 
 
 def opcatsrc_out(*args):
@@ -209,4 +205,3 @@ def opsub_out(*args):
         output_res.append(row)
 
     print(tabulate(output_res, tablefmt="plain"))
-

--- a/omg/cmd/get/olm.py
+++ b/omg/cmd/get/olm.py
@@ -120,5 +120,35 @@ def opgrp_out(*args):
 
 
 def opsub_out(*args):
-    print("WIP")
+    """
+    Operator InstallPlans parser.
+    """
+    ns = args[1]
+    show_labels = args[5]
+
+    output_res = _build_output_res(*args, fields=[
+        "NAME",
+        "PACKAGE",
+        "SOURCE",
+        "CHANNEL"
+    ])
+
+    for r in args[2]: # resource
+        rs = r["res"]
+        row = []
+
+        if ns == "_all":
+            row.append(rs["metadata"]["namespace"])
+
+        row.append(rs["metadata"]["name"])
+        row.append(rs["spec"]["name"])
+        row.append(rs["spec"]["source"])
+        row.append(rs["spec"]["channel"])
+
+        if show_labels:
+            row.append(extract_labels(rs))
+
+        output_res.append(row)
+
+    print(tabulate(output_res, tablefmt="plain"))
 

--- a/omg/cmd/get/olm.py
+++ b/omg/cmd/get/olm.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from tabulate import tabulate
+from omg.common.helper import age, extract_labels
+
+
+def opcsv_out(*args):
+    """
+    Operator ClusterServiceVersions parser.
+
+    # Positional args #:
+    # 0: t
+    # 1: ns
+    # 2: res
+    # 3: output
+    # 4: show_type
+    # 5: show_labels
+    """
+    ns = args[1]
+    show_labels = args[5]
+
+    output_res = [[]]
+    if ns == "_all": # ns
+        output_res[0].append("NAMESPACE")
+
+    output_res[0].extend([
+        "NAME",
+        "DISPLAY",
+        "VERSION",
+        "REPLACES",
+        "PHASE"
+    ])
+    if show_labels: # show_labels
+        output_res[0].extend(["LABELS"])
+
+    for r in args[2]: # resource
+        rs = r["res"]
+        row = []
+
+        if ns == "_all":
+            row.append(rs["metadata"]["namespace"])
+
+        row.append(rs["metadata"]["name"])
+        row.append(rs["spec"]["displayName"])
+        row.append(rs["spec"]["version"])
+        try:
+            row.append(rs["spec"]["replaces"])
+        except KeyError:
+            row.append('')
+        row.append(rs["status"]["phase"])
+
+        if show_labels:
+            row.append(extract_labels(rs))
+
+        output_res.append(row)
+    print(tabulate(output_res, tablefmt="plain"))
+
+
+def opip_out(*args):
+    print("WIP")
+
+
+def op_out(*args):
+    print("WIP")
+
+
+def opcatsrc_out(*args):
+    print("WIP")
+
+
+def opgrp_out(*args):
+    print("WIP")
+
+
+def opsub_out(*args):
+    print("WIP")
+

--- a/omg/cmd/get/olm.py
+++ b/omg/cmd/get/olm.py
@@ -108,7 +108,7 @@ def opip_out(*args):
 
 
 def op_out(*args):
-    print("WIP")
+    print("TODO")
 
 
 def opcatsrc_out(*args):
@@ -147,10 +147,34 @@ def opcatsrc_out(*args):
     print(tabulate(output_res, tablefmt="plain"))
 
 
-
-
 def opgrp_out(*args):
-    print("WIP")
+    """
+    Operator OperatorGroups parser.
+    """
+    ns = args[1]
+    show_labels = args[5]
+
+    output_res = _build_output_res(*args, fields=[
+        "NAME",
+        "AGE"
+    ])
+
+    for r in args[2]: # resource
+        rs = r["res"]
+        row = []
+
+        if ns == "_all":
+            row.append(rs["metadata"]["namespace"])
+
+        row.append(rs["metadata"]["name"])
+        row.append(age(rs["metadata"]["creationTimestamp"], r["gen_ts"]))
+
+        if show_labels:
+            row.append(extract_labels(rs))
+
+        output_res.append(row)
+
+    print(tabulate(output_res, tablefmt="plain"))
 
 
 def opsub_out(*args):

--- a/omg/cmd/get/olm.py
+++ b/omg/cmd/get/olm.py
@@ -112,7 +112,41 @@ def op_out(*args):
 
 
 def opcatsrc_out(*args):
-    print("WIP")
+    """
+    Operator CatalogSources parser.
+    """
+    ns = args[1]
+    show_labels = args[5]
+
+    output_res = _build_output_res(*args, fields=[
+        "NAME",
+        "DISPLAY",
+        "TYPE",
+        "PUBLISHER",
+        "AGE"
+    ])
+
+    for r in args[2]: # resource
+        rs = r["res"]
+        row = []
+
+        if ns == "_all":
+            row.append(rs["metadata"]["namespace"])
+
+        row.append(rs["metadata"]["name"])
+        row.append(rs["spec"]["displayName"])
+        row.append(rs["spec"]["sourceType"])
+        row.append(rs["spec"]["publisher"])
+        row.append(age(rs["metadata"]["creationTimestamp"], r["gen_ts"]))
+
+        if show_labels:
+            row.append(extract_labels(rs))
+
+        output_res.append(row)
+
+    print(tabulate(output_res, tablefmt="plain"))
+
+
 
 
 def opgrp_out(*args):
@@ -121,7 +155,7 @@ def opgrp_out(*args):
 
 def opsub_out(*args):
     """
-    Operator InstallPlans parser.
+    Operator Subscriptions parser.
     """
     ns = args[1]
     show_labels = args[5]

--- a/omg/common/resource_map.py
+++ b/omg/common/resource_map.py
@@ -508,8 +508,8 @@ map = [
         "yaml_loc": "namespaces/openshift-marketplace/operators.coreos.com/catalogsources",
     },
     {
-        "type": "operatorgroups",
-        "aliases": ["operatorgroups"],
+        "type": "operatorgroup",
+        "aliases": ["operatorgroups", "og"],
         "need_ns": True,
         "get_func": from_yaml,
         "getout_func": get_olm.opgrp_out,

--- a/omg/common/resource_map.py
+++ b/omg/common/resource_map.py
@@ -39,6 +39,7 @@ from omg.cmd.get.service_out import service_out
 from omg.cmd.get.simple_out import simple_out
 from omg.cmd.get.ss_out import ss_out
 from omg.cmd.get.vwhc_out import vwhc_out
+import omg.cmd.get.olm as get_olm
 from omg.common.config import Config
 
 # This map and function normalizes/standarizes the different names of object/resources types
@@ -479,7 +480,7 @@ map = [
         "aliases": ["clusterserviceversions", "csv"],
         "need_ns": True,
         "get_func": from_yaml,
-        "getout_func": csv_out,
+        "getout_func": get_olm.opcsv_out,
         "yaml_loc": "namespaces/%s/operators.coreos.com/clusterserviceversions",
     },
     {
@@ -487,7 +488,7 @@ map = [
         "aliases": ["installplans", "ip"],
         "need_ns": True,
         "get_func": from_yaml,
-        "getout_func": ip_out,
+        "getout_func": get_olm.opip_out,
         "yaml_loc": "namespaces/%s/operators.coreos.com/installplans",
     },
     {
@@ -495,7 +496,7 @@ map = [
         "aliases": ["operators"],
         "need_ns": False,
         "get_func": from_yaml,
-        "getout_func": op_out,
+        "getout_func": get_olm.op_out,
         "yaml_loc": "cluster-scoped-resources/operators.coreos.com/operators",
     },
     {
@@ -503,10 +504,25 @@ map = [
         "aliases": ["catsrc"],
         "need_ns": False,
         "get_func": from_yaml,
-        "getout_func": catsrc_out,
+        "getout_func": get_olm.opcatsrc_out,
         "yaml_loc": "namespaces/openshift-marketplace/operators.coreos.com/catalogsources",
     },
-    #> OLM TODO og (organizational groups): it seems to be inside catsrc
+    {
+        "type": "operatorgroups",
+        "aliases": ["operatorgroups"],
+        "need_ns": True,
+        "get_func": from_yaml,
+        "getout_func": get_olm.opgrp_out,
+        "yaml_loc": "namespaces/%s/operators.coreos.com/operatorgroups",
+    },
+    {
+        "type": "subscription",
+        "aliases": ["subscriptions", "sub"],
+        "need_ns": True,
+        "get_func": from_yaml,
+        "getout_func": get_olm.opsub_out,
+        "yaml_loc": "namespaces/%s/operators.coreos.com/subscriptions",
+    },
 ]
 
 

--- a/omg/common/resource_map.py
+++ b/omg/common/resource_map.py
@@ -473,6 +473,40 @@ map = [
         "getout_func": simple_out,
         "yaml_loc": "namespaces/%s/operator.openshift.io/ingresscontrollers",
     },
+    # OLM
+    {
+        "type": "clusterserviceversion",
+        "aliases": ["clusterserviceversions", "csv"],
+        "need_ns": True,
+        "get_func": from_yaml,
+        "getout_func": csv_out,
+        "yaml_loc": "namespaces/%s/operators.coreos.com/clusterserviceversions",
+    },
+    {
+        "type": "installplan",
+        "aliases": ["installplans", "ip"],
+        "need_ns": True,
+        "get_func": from_yaml,
+        "getout_func": ip_out,
+        "yaml_loc": "namespaces/%s/operators.coreos.com/installplans",
+    },
+    {
+        "type": "operator",
+        "aliases": ["operators"],
+        "need_ns": False,
+        "get_func": from_yaml,
+        "getout_func": op_out,
+        "yaml_loc": "cluster-scoped-resources/operators.coreos.com/operators",
+    },
+    {
+        "type": "catalogsources",
+        "aliases": ["catsrc"],
+        "need_ns": False,
+        "get_func": from_yaml,
+        "getout_func": catsrc_out,
+        "yaml_loc": "namespaces/openshift-marketplace/operators.coreos.com/catalogsources",
+    },
+    #> OLM TODO og (organizational groups): it seems to be inside catsrc
 ]
 
 

--- a/omg/common/resource_map.py
+++ b/omg/common/resource_map.py
@@ -496,7 +496,7 @@ map = [
         "aliases": ["operators"],
         "need_ns": False,
         "get_func": from_yaml,
-        "getout_func": get_olm.op_out,
+        "getout_func": simple_out,
         "yaml_loc": "cluster-scoped-resources/operators.coreos.com/operators",
     },
     {

--- a/omg/common/resource_map.py
+++ b/omg/common/resource_map.py
@@ -517,7 +517,7 @@ map = [
     },
     {
         "type": "subscription",
-        "aliases": ["subscriptions", "sub"],
+        "aliases": ["subscriptions", "sub", "subs"],
         "need_ns": True,
         "get_func": from_yaml,
         "getout_func": get_olm.opsub_out,


### PR DESCRIPTION
Introducing to [OLM RD](https://docs.openshift.com/container-platform/4.7/operators/understanding/olm/olm-understanding-olm.html#olm-resources_olm-understanding-olm):
- ClusterServiceVersions
- InstallPlans
- Subscriptions
- CatalogSources
- OperatorGroups

> OLM inspect is collected by default on MG since 4.7, there is a [issue](https://github.com/openshift/must-gather/issues/237) and [PR](https://github.com/openshift/must-gather/pull/242) opened to port it to 4.6.

## Steps to test

- Collect OLM data
~~~ 
oc adm inspect -A olm --dest-dir=tmp/mg-olm
~~~

- Install custom branch
~~~
python3 -m venv .venv && . ./.venv/bin/activate
pip install ./ --upgrade
omg use tmp/mg-olm/
omg get csv
~~~

- Test new cmds:
~~~
$ omg get csv
NAME                               DISPLAY                           VERSION   REPLACES                           PHASE
couchbase-operator.v2.1.0          Couchbase Operator                2.1.0     couchbase-operator.v2.0.2          Succeeded
elasticsearch-operator.5.0.5-11    OpenShift Elasticsearch Operator  5.0.5-11                                     Succeeded
jaeger-operator.v1.20.3            Red Hat OpenShift Jaeger          1.20.3                                       Succeeded
redhat-openshift-pipelines.v1.4.1  Red Hat OpenShift Pipelines       1.4.1     redhat-openshift-pipelines.v1.4.0  Succeeded

$ omg get csv -A |wc -l
316

$ oc get csv -A |wc -l
316

$ omg get ip -A  |wc -l
12

$ oc get ip -A  |wc -l
12

$ omg get subs -A |wc -l
11

$ oc get subs -A |wc -l
11

$ omg get catsrc -A  |wc -l
5

$ oc get catsrc -A  |wc -l
5

$ oc get og -A |wc -l
11

$ omg get og -A |wc -l
11

~~~