### PR TITLE
Added new "get" resources when ODF (former OCS) is installed on cluster

### DIFF
--- a/omg/cmd/get/cephblockpools_out.py
+++ b/omg/cmd/get/cephblockpools_out.py
@@ -4,46 +4,39 @@ from tabulate import tabulate
 from omg.common.helper import age, extract_labels
 
 
-def cephobjectstoreusers_out(t, ns, res, output, show_type, show_labels):
+def cephblockpools_out(t, ns, res, output, show_type, show_labels):
     output_res = [[]]
     # header
-    header = []
     if ns == "_all":
         output_res[0].append("NAMESPACE")
     if show_labels:
         output_res[0].extend(["NAME", "AGE", "LABELS"])
     else:
         output_res[0].extend(["NAME", "AGE"])
-        
+
     # resources
     for r in res:
-        co = r["res"]
+        cf = r["res"]
         row = []
         # namespace (for --all-namespaces)
         if ns == "_all":
-            row.append(co["metadata"]["namespace"])
+            row.append(cf["metadata"]["namespace"])
         # name
         if show_type:
-            row.append(t + "/" + co["metadata"]["name"])
+            row.append(t + "/" + cf["metadata"]["name"])
         else:
-            row.append(co["metadata"]["name"])
+            row.append(cf["metadata"]["name"])
         # age
         try:
-            ct = str(co["metadata"]["creationTimestamp"])
+            ct = str(cf["metadata"]["creationTimestamp"])
             ts = r["gen_ts"]
             row.append(age(ct, ts))
         except:
             row.append("Unknown")
 
         if show_labels:
-            row.append(extract_labels(co))
+            row.append(extract_labels(cf))
 
         output_res.append(row)
 
-    # sort by NAME column whose index will be
-    # 1 if we are showing namespaces otherwise 0
-    ni = 1 if ns == "_all" else 0
-    sorted_output = sorted(output_res, key=lambda x: x[ni])
-    sorted_output.insert(0, header)
-
-    print(tabulate(sorted_output, tablefmt="plain"))
+    print(tabulate(output_res, tablefmt="plain"))

--- a/omg/cmd/get/cephclusters_out.py
+++ b/omg/cmd/get/cephclusters_out.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from tabulate import tabulate
+
+from omg.common.helper import age, extract_labels
+
+
+def cephclusters_out(t, ns, res, output, show_type, show_labels):
+    output_res = [[]]
+    # header
+    if ns == "_all":
+        output_res[0].append("NAMESPACE")
+    if show_labels:
+        output_res[0].extend(["NAME", "DATADIRHOSTPATH", "MONCOUNT", "AGE","PHASE" , "MESSAGE", "HEALTH", "LABELS"])
+    else:
+        output_res[0].extend(["NAME", "DATADIRHOSTPATH", "MONCOUNT", "AGE","PHASE" , "MESSAGE", "HEALTH"])
+
+    # resources
+    for r in res:
+        cs = r["res"]
+        row = []
+        # namespace (for --all-namespaces)
+        if ns == "_all":
+            row.append(cs["metadata"]["namespace"])
+        # name
+        if show_type:
+            row.append(t + "/" + cs["metadata"]["name"])
+        else:
+            row.append(cs["metadata"]["name"])
+        # dataDirHostPath
+        row.append(cs["spec"]["dataDirHostPath"])
+        # mon.count
+        row.append(cs["spec"]["mon"]["count"])
+        # age
+        try:
+            ct = str(cs["metadata"]["creationTimestamp"])
+            ts = r["gen_ts"]
+            row.append(age(ct, ts))
+        except:
+            row.append("Unknown")
+        # phase
+        row.append(cs["status"]["phase"])
+        # message
+        row.append(cs["status"]["message"])
+        # health
+        row.append(cs["status"]["ceph"]["health"])
+
+        if show_labels:
+            row.append(extract_labels(cs))
+
+        output_res.append(row)
+
+    print(tabulate(output_res, tablefmt="plain"))

--- a/omg/cmd/get/cephfilesystems_out.py
+++ b/omg/cmd/get/cephfilesystems_out.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from tabulate import tabulate
+
+from omg.common.helper import age, extract_labels
+
+
+def cephfilesystems_out(t, ns, res, output, show_type, show_labels):
+    output_res = [[]]
+    # header
+    if ns == "_all":
+        output_res[0].append("NAMESPACE")
+    if show_labels:
+        output_res[0].extend(["NAME", "ACTIVEMDS", "AGE", "LABELS"])
+    else:
+        output_res[0].extend(["NAME", "ACTIVEMDS", "AGE"])
+
+    # resources
+    for r in res:
+        cf = r["res"]
+        row = []
+        # namespace (for --all-namespaces)
+        if ns == "_all":
+            row.append(cf["metadata"]["namespace"])
+        # name
+        if show_type:
+            row.append(t + "/" + cf["metadata"]["name"])
+        else:
+            row.append(cf["metadata"]["name"])
+        # activemds
+        row.append(cf["spec"]["metadataServer"]["activeCount"])
+        # age
+        try:
+            ct = str(cf["metadata"]["creationTimestamp"])
+            ts = r["gen_ts"]
+            row.append(age(ct, ts))
+        except:
+            row.append("Unknown")
+
+        if show_labels:
+            row.append(extract_labels(cf))
+
+        output_res.append(row)
+
+    print(tabulate(output_res, tablefmt="plain"))

--- a/omg/cmd/get/cephobjectstores_out.py
+++ b/omg/cmd/get/cephobjectstores_out.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from tabulate import tabulate
+
+from omg.common.helper import age, extract_labels
+
+
+def cephobjectstores_out(t, ns, res, output, show_type, show_labels):
+    output_res = [[]]
+    # header
+    if ns == "_all":
+        output_res[0].append("NAMESPACE")
+    if show_labels:
+        output_res[0].extend(["NAME", "AGE", "LABELS"])
+    else:
+        output_res[0].extend(["NAME", "AGE"])
+
+    # resources
+    for r in res:
+        co = r["res"]
+        row = []
+        # namespace (for --all-namespaces)
+        if ns == "_all":
+            row.append(co["metadata"]["namespace"])
+        # name
+        if show_type:
+            row.append(t + "/" + co["metadata"]["name"])
+        else:
+            row.append(co["metadata"]["name"])
+        # age
+        try:
+            ct = str(co["metadata"]["creationTimestamp"])
+            ts = r["gen_ts"]
+            row.append(age(ct, ts))
+        except:
+            row.append("Unknown")
+
+        if show_labels:
+            row.append(extract_labels(co))
+
+        output_res.append(row)
+
+    print(tabulate(output_res, tablefmt="plain"))

--- a/omg/cmd/get/cephobjectstoreusers_out.py
+++ b/omg/cmd/get/cephobjectstoreusers_out.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from tabulate import tabulate
+
+from omg.common.helper import age, extract_labels
+
+
+def cephobjectstoreusers_out(t, ns, res, output, show_type, show_labels):
+    output_res = [[]]
+    # header
+    header = []
+    if ns == "_all":
+        header.append("NAMESPACE")
+    if show_labels:
+        output_res[0].extend(["NAME", "AGE", "LABELS"])
+    else:
+        output_res[0].extend(["NAME", "AGE"])
+        
+    # resources
+    for r in res:
+        co = r["res"]
+        row = []
+        # namespace (for --all-namespaces)
+        if ns == "_all":
+            row.append(co["metadata"]["namespace"])
+        # name
+        if show_type:
+            row.append(t + "/" + co["metadata"]["name"])
+        else:
+            row.append(co["metadata"]["name"])
+        # age
+        try:
+            ct = str(co["metadata"]["creationTimestamp"])
+            ts = r["gen_ts"]
+            row.append(age(ct, ts))
+        except:
+            row.append("Unknown")
+
+        if show_labels:
+            row.append(extract_labels(co))
+
+        output_res.append(row)
+
+    # sort by NAME column whose index will be
+    # 1 if we are showing namespaces otherwise 0
+    ni = 1 if ns == "_all" else 0
+    sorted_output = sorted(output_res, key=lambda x: x[ni])
+    sorted_output.insert(0, header)
+
+    print(tabulate(sorted_output, tablefmt="plain"))

--- a/omg/cmd/get/csidrivers_out.py
+++ b/omg/cmd/get/csidrivers_out.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+from tabulate import tabulate
+
+from omg.common.helper import age
+
+
+def csidrivers_out(t, ns, res, output, show_type, show_labels):
+    output_res = []
+    # header
+    if show_labels:
+        header = [
+            "NAME",
+            "ATTACHREQUIRED",
+            "PODINFOONMOUNT",
+            "MODES",
+            "AGE",
+            "LABELS",
+        ]
+    else:
+        header = [
+            "NAME",
+            "ATTACHREQUIRED",
+            "PODINFOONMOUNT",
+            "MODES",
+            "AGE",
+        ]
+    # resources
+    for r in res:
+        cd = r["res"]
+        row = []
+        # name
+        if show_type:
+            row.append(t + "/" + cd["metadata"]["name"])
+        else:
+            row.append(cd["metadata"]["name"])
+        # attachRequired
+        row.append(cd["spec"]["attachRequired"])
+        # podInfoOnMount
+        row.append(cd["spec"]["podInfoOnMount"])
+        # volumeLifecycleModes
+        row.append(cd["spec"]["volumeLifecycleModes"][0])
+        # age
+        try:
+            ct = str(cd["metadata"]["creationTimestamp"])
+            ts = r["gen_ts"]
+            row.append(age(ct, ts))
+        except:
+            row.append("Unknown")
+
+        output_res.append(row)
+
+    # sort by 1st column
+    sorted_output = sorted(output_res)
+    sorted_output.insert(0, header)
+    print(tabulate(sorted_output, tablefmt="plain"))

--- a/omg/cmd/get/csinodes_out.py
+++ b/omg/cmd/get/csinodes_out.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from tabulate import tabulate
+
+from omg.common.helper import age
+
+
+def csinodes_out(t, ns, res, output, show_type, show_labels):
+    output_res = []
+    # header
+    if show_labels:
+        header = [
+            "NAME",
+            "DRIVERS",
+            "AGE",
+            "LABELS",
+        ]
+    else:
+        header = [
+            "NAME",
+            "DRIVERS",
+            "AGE",
+        ]
+    # resources
+    for r in res:
+        cn = r["res"]
+        row = []
+        # name
+        if show_type:
+            row.append(t + "/" + cn["metadata"]["name"])
+        else:
+            row.append(cn["metadata"]["name"])
+        # drivers
+        try:
+            row.append(len(cn["spec"]["drivers"]))
+        except:
+            row.append("0")
+        # age
+        try:
+            ct = str(cn["metadata"]["creationTimestamp"])
+            ts = r["gen_ts"]
+            row.append(age(ct, ts))
+        except:
+            row.append("Unknown")
+
+        output_res.append(row)
+
+    # sort by 1st column
+    sorted_output = sorted(output_res)
+    sorted_output.insert(0, header)
+    print(tabulate(sorted_output, tablefmt="plain"))

--- a/omg/cmd/get/va_out.py
+++ b/omg/cmd/get/va_out.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from tabulate import tabulate
+
+from omg.common.helper import age
+
+
+def va_out(t, ns, res, output, show_type, show_labels):
+    output_res = []
+    # header
+    if show_labels:
+        header = [
+            "NAME",
+            "ATTACHER",
+            "PV",
+            "NODE",
+            "ATTACHED",
+            "AGE",
+            "LABELS",
+        ]
+    else:
+        header = [
+            "NAME",
+            "ATTACHER",
+            "PV",
+            "NODE",
+            "ATTACHED",
+            "AGE",
+        ]
+    # resources
+    for r in res:
+        va = r["res"]
+        row = []
+        # name
+        if show_type:
+            row.append(t + "/" + va["metadata"]["name"])
+        else:
+            row.append(va["metadata"]["name"])
+        # attacher
+        row.append(va["spec"]["attacher"])
+        # pv
+        row.append(va["spec"]["source"]["persistentVolumeName"])
+        # node
+        row.append(va["spec"]["nodeName"])
+        # attached
+        row.append(va["status"]["attached"])
+        # age
+        try:
+            ct = str(va["metadata"]["creationTimestamp"])
+            ts = r["gen_ts"]
+            row.append(age(ct, ts))
+        except:
+            row.append("Unknown")
+
+        output_res.append(row)
+
+    # sort by 1st column
+    sorted_output = sorted(output_res)
+    sorted_output.insert(0, header)
+    print(tabulate(sorted_output, tablefmt="plain"))

--- a/omg/common/resource_map.py
+++ b/omg/common/resource_map.py
@@ -3,6 +3,7 @@ import os
 
 from omg.cmd.get.bc_out import bc_out
 from omg.cmd.get.build_out import build_out
+from omg.cmd.get.cephblockpools_out import cephblockpools_out
 from omg.cmd.get.cephclusters_out import cephclusters_out
 from omg.cmd.get.cephfilesystems_out import cephfilesystems_out
 from omg.cmd.get.cephobjectstores_out import cephobjectstores_out
@@ -88,6 +89,14 @@ map = [
         "get_func": from_yaml,
         "getout_func": bc_out,
         "yaml_loc": "namespaces/%s/build.openshift.io/buildconfigs.yaml",
+    },
+    {
+        "type": "cephblockpools",
+        "aliases": ["cephblockpools"],
+        "need_ns": True,
+        "get_func": from_yaml,
+        "getout_func": cephblockpools_out,
+        "yaml_loc": "ceph/namespaces/%s/ceph.rook.io/cephblockpools",
     },
     {
         "type": "cephclusters",

--- a/omg/common/resource_map.py
+++ b/omg/common/resource_map.py
@@ -3,10 +3,16 @@ import os
 
 from omg.cmd.get.bc_out import bc_out
 from omg.cmd.get.build_out import build_out
+from omg.cmd.get.cephclusters_out import cephclusters_out
+from omg.cmd.get.cephfilesystems_out import cephfilesystems_out
+from omg.cmd.get.cephobjectstores_out import cephobjectstores_out
+from omg.cmd.get.cephobjectstoreusers_out import cephobjectstoreusers_out
 from omg.cmd.get.cj_out import cj_out
 from omg.cmd.get.cm_out import cm_out
 from omg.cmd.get.co_out import co_out
 from omg.cmd.get.crd_out import crd_out
+from omg.cmd.get.csidrivers_out import csidrivers_out
+from omg.cmd.get.csinodes_out import csinodes_out
 from omg.cmd.get.csr_out import csr_out
 from omg.cmd.get.cv_out import cv_out
 from omg.cmd.get.dc_out import dc_out
@@ -39,6 +45,7 @@ from omg.cmd.get.secret_out import secret_out
 from omg.cmd.get.service_out import service_out
 from omg.cmd.get.simple_out import simple_out
 from omg.cmd.get.ss_out import ss_out
+from omg.cmd.get.va_out import va_out
 from omg.cmd.get.vwhc_out import vwhc_out
 import omg.cmd.get.olm as get_olm
 from omg.common.config import Config
@@ -81,6 +88,38 @@ map = [
         "get_func": from_yaml,
         "getout_func": bc_out,
         "yaml_loc": "namespaces/%s/build.openshift.io/buildconfigs.yaml",
+    },
+    {
+        "type": "cephclusters",
+        "aliases": ["cephclusters"],
+        "need_ns": True,
+        "get_func": from_yaml,
+        "getout_func": cephclusters_out,
+        "yaml_loc": "ceph/namespaces/%s/ceph.rook.io/cephclusters",
+    },
+    {
+        "type": "cephfilesystems",
+        "aliases": ["cephfilesystems"],
+        "need_ns": True,
+        "get_func": from_yaml,
+        "getout_func": cephfilesystems_out,
+        "yaml_loc": "ceph/namespaces/%s/ceph.rook.io/cephfilesystems",
+    },
+    {
+        "type": "cephobjectstores",
+        "aliases": ["cephobjectstores"],
+        "need_ns": True,
+        "get_func": from_yaml,
+        "getout_func": cephobjectstores_out,
+        "yaml_loc": "ceph/namespaces/%s/ceph.rook.io/cephobjectstores",
+    },
+    {
+        "type": "cephobjectstoreusers",
+        "aliases": ["cephobjectstoreusers"],
+        "need_ns": True,
+        "get_func": from_yaml,
+        "getout_func": cephobjectstoreusers_out,
+        "yaml_loc": "ceph/namespaces/%s/ceph.rook.io/cephobjectstoreusers",
     },
     {
         "type": "certificatesigningrequest",
@@ -129,6 +168,22 @@ map = [
         "get_func": from_yaml,
         "getout_func": cj_out,
         "yaml_loc": "namespaces/%s/batch/cronjobs.yaml",
+    },
+    {
+        "type": "csidrivers",
+        "aliases": ["csidrivers"],
+        "need_ns": False,
+        "get_func": from_yaml,
+        "getout_func": csidrivers_out,
+        "yaml_loc": "cluster-scoped-resources/storage.k8s.io/csidrivers",
+    },
+    {
+        "type": "csinodes",
+        "aliases": ["csinodes"],
+        "need_ns": False,
+        "get_func": from_yaml,
+        "getout_func": csinodes_out,
+        "yaml_loc": "cluster-scoped-resources/storage.k8s.io/csinodes",
     },
     {
         "type": "customresourcedefinition",
@@ -531,6 +586,14 @@ map = [
         "get_func": from_yaml,
         "getout_func": get_olm.opsub_out,
         "yaml_loc": "namespaces/%s/operators.coreos.com/subscriptions",
+    },
+    {
+        "type": "volumeattachments",
+        "aliases": ["volumeattachments"],
+        "need_ns": False,
+        "get_func": from_yaml,
+        "getout_func": va_out,
+        "yaml_loc": "cluster-scoped-resources/storage.k8s.io/volumeattachments",
     },
 ]
 


### PR DESCRIPTION
Hello @kxr,

I have added new resources that are created on the cluster when you install ODF in an OCP cluster. They are:

```
$ omg get volumeattachments 
NAME                                                                  ATTACHER                            PV                                        NODE                   ATTACHED  AGE
csi-53e56f4c95184bf973b2437bdb518ae3dfafe23952c2e50d067e60b2aa0309ed  openshift-storage.rbd.csi.ceph.com  pvc-89ef98f8-6bd8-4028-a7b0-4a0e0130ac1f  brcsfpadvop4wor-qz4j4  True      9d
csi-8ea202afbc1d82cb8e00b62e634553d5472436f618cb9ab2d2b0ef47d03d1f8c  openshift-storage.rbd.csi.ceph.com  pvc-cc08eda5-b0fc-419d-b984-dd4b59465c4b  brcsfpadvop4stg-p2h28  True      10d
...
<output ommited>

$ omg get csidrivers
NAME                                   ATTACHREQUIRED  PODINFOONMOUNT  MODES       AGE
openshift-storage.cephfs.csi.ceph.com  True            False           Persistent  61d
openshift-storage.rbd.csi.ceph.com     True            False           Persistent  61d

$ omg get csinodes 
NAME                                                DRIVERS  AGE
brcsfpadvop4dev-2mltd                               2        19d
brcsfpadvop4dev-r2qd7                               2        19d
brcsfpadvop4inf-92trj                               2        61d
brcsfpadvop4m01                               0        65d
brcsfpadvop4m02                               0        65d
...
<output ommited>

$ omg get cephclusters -A --show-labels
NAMESPACE          NAME                            DATADIRHOSTPATH  MONCOUNT  AGE  PHASE  MESSAGE                       HEALTH       LABELS
openshift-storage  ocs-storagecluster-cephcluster  /var/lib/rook    3         61d  Ready  Cluster created successfully  HEALTH_WARN  app=ocs-storagecluster

$ omg get cephblockpools -A
NAMESPACE          NAME                              AGE
openshift-storage  ocs-storagecluster-cephblockpool  61d

$ omg get cephfilesystems -A --show-labels
NAMESPACE          NAME                               ACTIVEMDS  AGE  LABELS
openshift-storage  ocs-storagecluster-cephfilesystem  1          61d  ceph_version=14.2.11-147-nautilus

$ omg get cephobjectstores -A --show-labels
NAMESPACE          NAME                                AGE  LABELS
openshift-storage  ocs-storagecluster-cephobjectstore  61d  ceph_version=14.2.11-147-nautilus

$ omg get cephobjectstoreusers  -A
NAMESPACE          NAME                                    AGE
openshift-storage  noobaa-ceph-objectstore-user            61d
openshift-storage  ocs-storagecluster-cephobjectstoreuser  61d
```

There are other resources that are created on the cluster but I have not tested them yet. I am going to test it on OCP before implement it on omg.