### PR TITLE
Add missing resource shortnames

### DIFF
--- a/omg/common/resource_map.py
+++ b/omg/common/resource_map.py
@@ -372,7 +372,7 @@ map = [
     },
     {
         "type": "node",
-        "aliases": ["nodes"],
+        "aliases": ["nodes", "no"],
         "need_ns": False,
         "get_func": from_yaml,
         "getout_func": node_out,


### PR DESCRIPTION
This commit adds the missing shortnames for the following resources:

* nodes
* statefulsets
* cronjobs
* ingresses
* networkpolicies
* clusterserviceversions

The shortnames were retrieved from an OCP 4.8 / Kubernetes 1.21.1 cluster. The output for `oc api-resources` shows these shortnames:

~~~
$ oc api-resources
NAME                                  SHORTNAMES       APIVERSION                                    NAMESPACED   KIND
statefulsets                          sts              apps/v1                                       true         StatefulSet
cronjobs                              cj               batch/v1                                      true         CronJob
ingresses                             ing              extensions/v1beta1                            true         Ingress
networkpolicies                       netpol           networking.k8s.io/v1                          true         NetworkPolicy
clusterserviceversions                csv,csvs         operators.coreos.com/v1alpha1                 true         ClusterServiceVersion
~~~

Fixes issue #64