### PR TITLE
Allow 'omg use' to inflate a must gather file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ Use it like oc:
   valid file?:
   - It is a tar file, we use tarfile module to validate that, not just by extension.
   - It have only one root directory inside the tar file and the name starts with "must-gather".
-  Once it match this criteria the file is uncompressed on the current directory and it move 
+  Once it match this criteria the file is uncompressed on the current directory and it move to the standard 'omg use' flow.
+
+
 ### `omg machine-config`
 
 This feature assist you in exploring the MachineConfigs in a more human-friendly way. You can use it in the following

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Point it to an extracted must-gather:
 
     $ omg use </path/to/must-gather/>
 
+Or you can point directly to the file, omg will validate and uncompress it for you:
+
+    $ omg use <must-gather-tar-file>
+
 Use it like oc:
 
     # omg get clusterVersion
@@ -83,6 +87,11 @@ Use it like oc:
             Cluster API URL: ['https://api.ocpprod.example.com:6443']
            Cluster Platform: ['None']
 
+- You can now point the omg command to a file and it will uncompress it for you, but **only** if is a valid file. What is a 
+  valid file?:
+  - It is a tar file, we use tarfile module to validate that, not just by extension.
+  - It have only one root directory inside the tar file and the name starts with "must-gather".
+  Once it match this criteria the file is uncompressed on the current directory and it move 
 ### `omg machine-config`
 
 This feature assist you in exploring the MachineConfigs in a more human-friendly way. You can use it in the following

--- a/omg/cli.py
+++ b/omg/cli.py
@@ -41,7 +41,7 @@ def cli():
 @click.argument(
     "mg_path",
     required=False,
-    type=click.Path(exists=True, file_okay=False, resolve_path=True, allow_dash=False),
+    type=click.Path(exists=True, file_okay=True, resolve_path=True, allow_dash=False),
 )
 @click.option("--cwd", is_flag=True)
 def use_cmd(mg_path, cwd):

--- a/omg/cmd/use.py
+++ b/omg/cmd/use.py
@@ -2,7 +2,7 @@
 import os
 
 from omg.common.config import Config
-
+from omg.common.inflator import inflate_file
 
 def use(mg_path, cwd):
     if mg_path is None:
@@ -21,7 +21,6 @@ def use(mg_path, cwd):
             print("    Current Project: %s" % project)
             try:
                 from omg.cmd.get_main import get_resources
-
                 infra = get_resources("Infrastructure")
                 apiServerURL = [i["res"]["status"]["apiServerURL"] for i in infra]
                 platform = [i["res"]["status"]["platform"] for i in infra]
@@ -32,6 +31,15 @@ def use(mg_path, cwd):
     else:
         c = Config(fail_if_no_path=False)
         p = mg_path
+        # Check if the 'path' is a file:
+        if os.path.isfile(p):
+            # So, if is a file, try to inflate it:
+            real_p = inflate_file(p)
+            if not real_p:
+                return
+            # If is all ok, we now set the uncompress directory as the new 'p'
+            #  and we let the "use" flow continue:
+            p = real_p
         # We traverse up to 3 levels to find the must-gather
         # At each leve if it has only one dir and we check inside it
         # When we see see the dir /namespaces and /cluster-scoped-resources, we assume it

--- a/omg/common/inflator.py
+++ b/omg/common/inflator.py
@@ -1,0 +1,55 @@
+import os
+import tarfile
+
+__supported_extensions = [
+    '.tar.gz',
+    '.tar.bz2',
+    '.tar.xz',
+    '.tgz',
+    '.tbz',
+    '.tbz2',
+    '.txz',
+]
+
+
+def __get_rootdir_info(inflator):
+    finfo_list = inflator.getmembers()
+    # Get the root directories:
+    rootdir = None
+    for finfo in finfo_list:
+        if finfo.isdir() and finfo.name.count('/') == 0:
+            rootdir = finfo
+            break
+    return rootdir
+    
+# Left path_to_extract as an option, default to current directory.
+# We need to further modify the use command to use it correctly, but
+# I prefer to not apply that changes at this state. Feel free to add
+# the change if you feel that could be useful.
+def inflate_file(filename, path_to_extract='./'):
+    print('Trying to uncompress:', filename, 'to', path_to_extract)
+    if not tarfile.is_tarfile(filename):
+        print('[ERROR] This is not a valid TAR file.')
+        return None
+    print('File looks ok!, opening now.')
+    inflator = tarfile.open(filename, 'r')
+    rootdir = __get_rootdir_info(inflator)
+    if not rootdir:
+        print(
+            '[ERROR] There is not a root directory in the file, that is not good, '
+            'uncompress and check the file manually'
+        )
+        return None
+    # Check for file contents, we must have a 
+    #  'must-gather.*' directory on the root of the compressed file
+    if not rootdir.name.startswith('must-gather'):
+        print(
+            '[ERROR] Root directoty do not match "must-gather*", that is not good, '
+            'uncompress and check the file manually'
+        )
+        return None
+    # Extract all the files:
+    print('Extracting files')
+    inflator.extractall(path_to_extract)
+    # return the name of the extracted path
+    return rootdir.name

--- a/omg/common/inflator.py
+++ b/omg/common/inflator.py
@@ -1,16 +1,6 @@
 import os
 import tarfile
 
-__supported_extensions = [
-    '.tar.gz',
-    '.tar.bz2',
-    '.tar.xz',
-    '.tgz',
-    '.tbz',
-    '.tbz2',
-    '.txz',
-]
-
 
 def __get_rootdir_info(inflator):
     finfo_list = inflator.getmembers()
@@ -29,9 +19,9 @@ def __get_rootdir_info(inflator):
 def inflate_file(filename, path_to_extract='./'):
     print('Trying to uncompress:', filename, 'to', path_to_extract)
     if not tarfile.is_tarfile(filename):
-        print('[ERROR] This is not a valid TAR file.')
+        print('[ERROR] This is not a valid .tar.{gz,bz2,xz} / .t{gz,bz,bz2,xz} file.')
         return None
-    print('File looks ok!, opening now.')
+    print('File looks like a .tar, opening now and checking content structure.')
     inflator = tarfile.open(filename, 'r')
     rootdir = __get_rootdir_info(inflator)
     if not rootdir:
@@ -49,7 +39,7 @@ def inflate_file(filename, path_to_extract='./'):
         )
         return None
     # Extract all the files:
-    print('Extracting files')
+    print('Looks like a must-gather tar file, extracting')
     inflator.extractall(path_to_extract)
     # return the name of the extracted path
     return rootdir.name


### PR DESCRIPTION
This PR enable the 'omg use'  subcommand to be used directly with a valid must-gather compressed file.
 What is a valid must-gather file?:
- It is a .tar.{gz,bz2,xz} / .{tgz,tbz,tbz2,txz} file, using tarfile.is_tarfile() to validate that.
- It have only one root directory inside the tar file and the name starts with "must-gather".
Once it match this criteria the file is uncompressed on the current directory and then it move to the standard 'omg use' flow, the code just add what it needs to first uncompress the file and then keep the previous command behaviour.
If the file don't match the criteria mentioned an error is shown and file is not uncompressed.