### PR TITLE
Show SDN Plugin installed in omg use output

### DIFF
--- a/omg/cmd/use.py
+++ b/omg/cmd/use.py
@@ -23,10 +23,13 @@ def use(mg_path, cwd):
                 from omg.cmd.get_main import get_resources
 
                 infra = get_resources("Infrastructure")
+                network = get_resources("Network")
                 apiServerURL = [i["res"]["status"]["apiServerURL"] for i in infra]
                 platform = [i["res"]["status"]["platform"] for i in infra]
+                sdn = [n["res"]["status"]["networkType"] for n in network]
                 print("    Cluster API URL: %s" % str(apiServerURL))
                 print("   Cluster Platform: %s" % str(platform))
+                print(" Cluster SDN Plugin: %s" % str(sdn))
             except:
                 print("[ERROR] Unable to determine cluster API URL and Platform.")
     else:


### PR DESCRIPTION
The output of omg use is very useful as it helps to make sure one is looking at the correct must-gather but is also providing some useful information straight away about the Cluster, such as API URL and the platform it's running on. As the SDN plugin can differ between every installation it might be very useful to see the plugin configured by default as well. Given that different SDN plugins offer different solution and approaches it's key to understand what is being used as it could have an impact on troubleshooting and general understanding of the must-gather.

Example output are as following:

```
    Cluster API URL: ['https://api.foo.example.com:6443']
   Cluster Platform: ['None']
 Cluster SDN Plugin: ['OpenShiftSDN']
```
```
    Cluster API URL: ['https://api.bar.example.com:6443']
   Cluster Platform: ['OpenStack']
 Cluster SDN Plugin: ['Kuryr']
```