### PR TITLE
ADD: netnamespaces and hostsubnets resources support

### DIFF
--- a/omg/cmd/get/hostsubnets_out.py
+++ b/omg/cmd/get/hostsubnets_out.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from tabulate import tabulate
+
+from omg.common.helper import age
+
+
+def hostsubnets_out(t, ns, res, output, show_type, show_labels):
+    output_res = [[]]
+    # header
+    output_res[0].extend(["NAME", "HOST", "HOST IP", "SUBNET", "EGRESS CIDRS", "EGRESS IPS"])
+    # resources
+    for r in res:
+        h = r["res"]
+        row = []
+        # name
+        if show_type:
+            row.append(t + "/" + h["metadata"]["name"])
+        else:
+            row.append(h["metadata"]["name"])
+        # netid
+        try:
+            row.append(str(h["host"]))
+        except:
+            row.append("Unknown")
+        # hostIP
+        try:
+            row.append(str(h["hostIP"]))
+        except:
+            row.append("Unknown")
+        # subnet
+        try:
+            row.append(str(h["subnet"]))
+        except:
+            row.append("Unknown")
+        # egressCIDRs
+        try:
+            row.append(str(h["egressCIDRs"]))
+        except:
+            row.append("")
+        # egressIPs
+        try:
+            row.append(str(h["egressIPs"]))
+        except:
+            row.append("")
+
+        output_res.append(row)
+
+    print(tabulate(output_res, tablefmt="plain"))

--- a/omg/cmd/get/netnamespaces_out.py
+++ b/omg/cmd/get/netnamespaces_out.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from tabulate import tabulate
+
+from omg.common.helper import age
+
+
+def netnamespaces_out(t, ns, res, output, show_type, show_labels):
+    output_res = [[]]
+    # header
+    output_res[0].extend(["NAME", "NETID", "EGRESS IPS"])
+    # resources
+    for r in res:
+        n = r["res"]
+        row = []
+        # name
+        if show_type:
+            row.append(t + "/" + n["metadata"]["name"])
+        else:
+            row.append(n["metadata"]["name"])
+        # netid
+        try:
+            row.append(str(n["netid"]))
+        except:
+            row.append("Unknown")
+        # egressIPs
+        try:
+            row.append(str(n["egressIPs"]))
+        except:
+            row.append("")
+
+        output_res.append(row)
+
+    print(tabulate(output_res, tablefmt="plain"))

--- a/omg/common/resource_map.py
+++ b/omg/common/resource_map.py
@@ -48,6 +48,8 @@ from omg.cmd.get.simple_out import simple_out
 from omg.cmd.get.ss_out import ss_out
 from omg.cmd.get.va_out import va_out
 from omg.cmd.get.vwhc_out import vwhc_out
+from omg.cmd.get.netnamespaces_out import netnamespaces_out
+from omg.cmd.get.hostsubnets_out import hostsubnets_out
 import omg.cmd.get.olm as get_olm
 from omg.common.config import Config
 
@@ -603,6 +605,22 @@ map = [
         "get_func": from_yaml,
         "getout_func": va_out,
         "yaml_loc": "cluster-scoped-resources/storage.k8s.io/volumeattachments",
+    },
+    {
+        "type": "netnamespaces",
+        "aliases": ["netnamespaces"],
+        "need_ns": False,
+        "get_func": from_yaml,
+        "getout_func": netnamespaces_out,
+        "yaml_loc": "cluster-scoped-resources/network.openshift.io/netnamespaces",
+    },
+    {
+        "type": "hostsubnets",
+        "aliases": ["hostsubnets"],
+        "need_ns": False,
+        "get_func": from_yaml,
+        "getout_func": hostsubnets_out,
+        "yaml_loc": "cluster-scoped-resources/network.openshift.io/hostsubnets",
     },
 ]
 


### PR DESCRIPTION
Hi,

this PR adds support for `netnamespaces` and `hostsubnets`, even if they are not included anymore in the official must-gather is quite handy to have them: troubleshooting egressIPs issues can be tricky without a tool to easily show them.