### PR TITLE
Fix "omg get nodes -o wide" output in dual-stack clusters

### DIFF
--- a/omg/cmd/get/node_out.py
+++ b/omg/cmd/get/node_out.py
@@ -81,9 +81,9 @@ def node_out(t, ns, res, output, show_type, show_labels):
             e_ip = "<none>"
             addresses = n["status"]["addresses"]
             for a in addresses:
-                if a["type"] == "InternalIP":
+                if a["type"] == "InternalIP" and i_ip == "<none>":
                     i_ip = a["address"]
-                if a["type"] == "ExternalIP":
+                if a["type"] == "ExternalIP" and e_ip == "<none>":
                     e_ip = a["address"]
             row.append(i_ip)
             row.append(e_ip)


### PR DESCRIPTION
It was showing the last IP of each type, in contrast to "oc", which would show the first.

----

Probably not the best fix... It might be better to leave the values uninitialized and set them to "<none>" afterward if they don't otherwise get set? Except I haven't done much python in a long time and didn't want to try anything clever...

Also, I don't know if the same problem exists in other places. I just noticed this because it caused some confusion in a customer case.