### PR TITLE
fix/cmd-parser-alerts: fix alert path moved to rules.json

### DIFF
--- a/omg/cmd/parser/__init__.py
+++ b/omg/cmd/parser/__init__.py
@@ -43,15 +43,15 @@ parser_map = {
     "alerts":
         {
             "command": "alerts",
-            "helper": "Parser alerts exported by must-gather monitoring/alerts.json",
-            "file_in": "monitoring/alerts.json",
+            "helper": "Parser alerts exported by must-gather monitoring/prometheus/rules.json",
+            "file_in": "monitoring/prometheus/rules.json",
             "fn_out": alerts_summary
         },
     "alerts-firing":
         {
             "command": "alerts-firing",
-            "helper": "Parser alerts firing exported by must-gather monitoring/alerts.json",
-            "file_in": "monitoring/alerts.json",
+            "helper": "Parser alerts firing exported by must-gather monitoring/prometheus/rules.json",
+            "file_in": "monitoring/prometheus/rules.json",
             "fn_out": alerts_firing
         }
 }

--- a/omg/cmd/parser/alerts_out.py
+++ b/omg/cmd/parser/alerts_out.py
@@ -12,6 +12,8 @@ def alerts_summary(buffer=None):
     alerts = []
     for g in data['data']['groups']:
         for r in g['rules']:
+            if (r['type'] != "alerting"):
+                continue
             alerts.append({
                 "GroupName": g['name'],
                 "Name": r['name'],
@@ -33,7 +35,7 @@ def alerts_firing(buffer=None):
     for g in data['data']['groups']:
 
         for r in g['rules']:
-            if len(r['alerts']) <= 0:
+            if (r['type'] != "alerting") and (r['state'] != "firing"):
                 continue
 
             for a in r['alerts']:


### PR DESCRIPTION
Fix the Parser of commands `alerts` and `alerts-firing` with the correct path on must-gather.