### PR TITLE
remove cryptography's upper bound so that it can be used on Mac

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [wheel]
 universal = 1
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 import omg
 
 #dependencies = ['tabulate', 'pyyaml', 'python-dateutil', 'cryptography>=2.5,<=3.3.2', 'click==7.1.2']
-dependencies = ['tabulate', 'pyyaml', 'python-dateutil', 'cryptography>=2.5,<=3.3.2', 'click==8.0.1', 'loguru==0.6.0']
+dependencies = ['tabulate', 'pyyaml', 'python-dateutil', 'cryptography>=2.5', 'click==8.0.1', 'loguru==0.6.0']
 
 setup(
     name='o-must-gather',


### PR DESCRIPTION
Address https://github.com/pyca/cryptography/issues/8699
It works, 
```yaml
MacBook-Pro:o-must-gather jianzhang$ omg 
2023-04-10 16:56:11.287 | WARNING  | omg.utils.load_yaml:<module>:10 - yaml.CSafeLoader failed to load, using SafeLoader
Usage: omg [OPTIONS] COMMAND [ARGS]...

Options:
  -l, --loglevel [normal|info|debug|trace]
  -P, --path INTEGER
  -n, --namespace TEXT
  -A, --all-namespaces
  --help                          Show this message and exit.

Commands:
  ceph
  completion      Output shell completion code for the specified shell...
  etcdctl
  get             Display one or many resources
  logs            Print the logs for a container in a pod
  machine-config  Explore Machine Configs
  project         Switch to another project
  projects        Display existing projects
  rados
  rbd
  use             Select one or more must-gather(s) to use
  version         Prints the version of o-must-gather
  whoami          Tell you who you are
MacBook-Pro:o-must-gather jianzhang$ omg version
2023-04-10 16:56:15.094 | WARNING  | omg.utils.load_yaml:<module>:10 - yaml.CSafeLoader failed to load, using SafeLoader

omg version 2.0.0 (https://github.com/kxr/o-must-gather)
```