### PR TITLE
use BaseLoader instead of SafeLoader

### DIFF
--- a/omg/utils/load_yaml.py
+++ b/omg/utils/load_yaml.py
@@ -30,7 +30,7 @@ def load_yaml(yfile):
         lg.debug("Opened yaml file: " + yfile)
         y_d = y_f.read()
         try:
-            ydata = yaml.load(y_d, Loader=SafeLoader)
+            ydata = yaml.load(y_d, Loader=yaml.BaseLoader)
         except (yaml.scanner.ScannerError, yaml.parser.ParserError):
             # yaml load/parse failed
             # try skipping lines from the bottom
@@ -43,7 +43,7 @@ def load_yaml(yfile):
                 y_d = y_d[:y_d.rfind("\n")]
                 lines_skipped += 1
                 try:
-                    ydata = yaml.load(y_d, Loader=SafeLoader)
+                    ydata = yaml.load(y_d, Loader=yaml.BaseLoader)
                 except (yaml.scanner.ScannerError, yaml.parser.ParserError):
                     pass
                 else:

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -20,7 +20,7 @@ def test_use_simple_must_gather(caplog, omgconfig, simple_must_gather):
         cfile=omgconfig
     )
     with open(omgconfig, "r") as omgcfg:
-        cfg = yaml.load(omgcfg.read(), Loader=yaml.SafeLoader)
+        cfg = yaml.load(omgcfg.read(), Loader=yaml.BaseLoader)
     for path in cfg["paths"]:
         assert os.path.isdir(path)
         assert (


### PR DESCRIPTION
After this PR, we can get the `crd` successfully. Addressed #82 
```console
jiazha-mac:o-must-gather jiazha$ omg get crd 
NAME                                                                 CREATED AT
awsclusterstaticidentities.infrastructure.cluster.x-k8s.io           2023-12-23T10:50:13Z
variables.compliance.openshift.io                                    2023-12-23T12:11:29Z
nodes.config.openshift.io                                            2023-12-23T10:48:38Z
kafkausers.kafka.strimzi.io                                          2023-12-23T12:09:23Z
...
```