### PR TITLE
add  yaml.constructor.ConstructorError capture

### DIFF
--- a/omg/must_gather/generate_rdefs.py
+++ b/omg/must_gather/generate_rdefs.py
@@ -26,12 +26,14 @@ def generate_rdefs(path):
         try:
             with open(rdefs_f, "r") as r_f:
                 rdefs.extend(yaml.safe_load(r_f))
-        except Exception:
-            pass
+        except Exception as e:
+            lg.error("Error loading existing rdefs: {}".format(e))
+    else:
+        lg.info("{} file does not exist. It will be created.".format(rdefs_f))
 
     try:
         crds = load_res(path, "crd")
-
+        lg.trace("load path {} successfully".format(path))
         if crds:
             for crd in crds:
 
@@ -47,11 +49,14 @@ def generate_rdefs(path):
 
                 if rdef not in rdefs:
                     rdefs.append(rdef)
+            try:
+                with open(rdefs_f, "w") as rdf:
+                    yaml.safe_dump(rdefs, rdf, default_flow_style=False)
+                    lg.debug("{} rdefs written to: {}".format(len(rdefs), rdefs_f))
+            except yaml.YAMLError as exc:
+                lg.error("YAML error while writing {}: {}".format(rdefs_f, exc))
+            except Exception as exc:
+                lg.error("Error writing {}: {}".format(rdefs_f, exc))
 
-            with open(rdefs_f, "w") as rdf:
-                yaml.dump(rdefs, rdf, default_flow_style=False)
-                lg.debug("{} rdefs written to: {}".format(len(rdefs), rdefs_f))
-
-    except Exception:
-        # lg.warning("Unable to generate rdef file {}: {}".format(rdefs_f, e))
-        pass
+    except Exception as e:
+        lg.error("Unable to generate rdef file {}: {}".format(rdefs_f, e))

--- a/omg/utils/load_yaml.py
+++ b/omg/utils/load_yaml.py
@@ -27,31 +27,34 @@ def load_yaml(yfile):
 
     ydata = None
     with open(yfile, "r") as y_f:
-        lg.debug("Opened yaml file: " + yfile)
         y_d = y_f.read()
         try:
             ydata = yaml.load(y_d, Loader=SafeLoader)
-        except (yaml.scanner.ScannerError, yaml.parser.ParserError):
-            # yaml load/parse failed
-            # try skipping lines from the bottom
-            # Until we are able to load the yaml file
-            # We will try until > 1 lines are left
-            lines_total = y_d.count("\n")
-            lines_skipped = 0
-            while y_d.count("\n") > 1:
-                # skip last line
-                y_d = y_d[:y_d.rfind("\n")]
-                lines_skipped += 1
-                try:
-                    ydata = yaml.load(y_d, Loader=SafeLoader)
-                except (yaml.scanner.ScannerError, yaml.parser.ParserError):
-                    pass
-                else:
-                    lg.warning("Skipped " +
-                               str(lines_skipped) + "/" + str(lines_total) +
-                               " lines from the end of " + yfile +
-                               " to the load the yaml file properly")
-                    break
+        except (yaml.scanner.ScannerError, yaml.parser.ParserError, yaml.constructor.ConstructorError):
+            lg.trace("Fail Opened yaml file: " + yfile)
+            pass
+            # # yaml load/parse failed
+            # # try skipping lines from the bottom
+            # # Until we are able to load the yaml file
+            # # We will try until > 1 lines are left
+            # lg.error("Fail Opened yaml file: " + yfile)
+            # lines_total = y_d.count("\n")
+            # lines_skipped = 0
+            # while y_d.count("\n") > 1:
+            #     # skip last line
+            #     y_d = y_d[:y_d.rfind("\n")]
+            #     lines_skipped += 1
+            #     try:
+            #         ydata = yaml.load(y_d, Loader=SafeLoader)
+            #     except (yaml.scanner.ScannerError, yaml.parser.ParserError, yaml.constructor.ConstructorError):
+            #         lg.error("lines_skipped {}, lines_total {}".format(lines_skipped, lines_total))
+            #         pass
+            #     else:
+            #         lg.error("Skipped " +
+            #                    str(lines_skipped) + "/" + str(lines_total) +
+            #                    " lines from the end of " + yfile +
+            #                    " to the load the yaml file properly")
+            #         break
 
     lg.debug("yaml file loaded in ydata. type: " + str(type(ydata)))
     lg.trace("ydata: " + str(ydata))


### PR DESCRIPTION
To solve issue #84 
```console
jiazha-mac:o-must-gather jiazha$ omg use ~/must-gather/must-gather-tp3 
WARNING Resource loaded from /Users/jiazha/must-gather/must-gather-tp3/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-2a156a46709ac22dc63b1231c7450db73a2d90aff74d96e2a42cf040f2f8c78f/cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions/alertmanagerconfigs.monitoring.rhobs.yaml is not valid
WARNING Resource loaded from /Users/jiazha/must-gather/must-gather-tp3/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-2a156a46709ac22dc63b1231c7450db73a2d90aff74d96e2a42cf040f2f8c78f/cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions/alertmanagerconfigs.monitoring.coreos.com.yaml is not valid
Selected must-gather: /Users/jiazha/must-gather/must-gather-tp3/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256*
            Projects: 79
             API URL: ['https://api.qe-daily-417-0906.qe.devcluster.openshift.com:6443']
            Platform: ['AWS']
          Cluster ID: ['e640061f-6221-4c53-a21c-e40da567c34c']
     Desired Version: ['4.17.0-0.nightly-2024-09-05-082755']

     Current Project: openshift-catalogd

jiazha-mac:o-must-gather jiazha$ omg get clustercatalog
No resources found
```